### PR TITLE
ci: add test workflow (build, vet, test, -race) on PRs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: false  # avoid tar "File exists" when restoring cache with toolchain files
 
       - name: Create results directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+# CI: build, vet, and test (including -race) on every PR and push to develop/main.
+# go.mod requires go 1.24.0; the matrix covers that floor plus the latest stable release so
+# neither a too-old nor a too-new toolchain silently goes unchecked.
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.24", "stable"]
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: false  # avoid tar "File exists" when restoring cache with toolchain files
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Test with race detector
+        run: go test -race ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: false  # avoid tar "File exists" when restoring cache with toolchain files
 
       - name: Bump version and create tag


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`: runs `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race ./...` on every PR and push to `develop`/`main`. Matrix covers `go.mod`'s floor (1.24) and the latest stable Go release, on `ubuntu-latest` and `macos-latest`.
- Previously nothing ran the test suite in CI — `release.yml` only tags+publishes on push to `main`, `benchmarks.yml` only runs the benchmark suite. Correctness was on the honor system; this is exactly the gap that let #5 (and the regression caught in review on #24) go unnoticed by anything but a human reading the diff.
- Bundled fix: `release.yml`/`benchmarks.yml` installed Go 1.23 while `go.mod` requires 1.24.0 — a one-line version-string fix per file, same underlying issue as the new workflow's version handling, so it's included here rather than left inconsistent.

Fixes #11
Fixes #17

## Test plan
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"` for all three workflow files
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./...` all run locally with the exact commands the new workflow uses
- [ ] First real run on this PR's own CI (can't self-verify before merge — that's the point of this PR)