### PR TITLE
docs(specs): document the ToEqual equality-semantics divergence

### DIFF
--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -99,7 +99,7 @@ ctx.Expect(value).To(specs.Equal(expected))
 | `ExpectT(ctx, x).ToEqual(y)` | `T comparable` (compile-time) | Go's `==`, always. No reflection. |
 | `ctx.Expect(x).ToEqual(y)` | `any` | `==` for `int`/`string`/`bool`/`int64`/`float64`/`uint` (fast path), `reflect.DeepEqual` for everything else. |
 
-The `comparable`-constrained pair (`EqualTo`/`ExpectT`) can't even be called with a slice or map — that's a compile error, not a runtime surprise. But for a struct (or any type) that holds a pointer, interface, or other reference field, `==` compares those fields by identity while `reflect.DeepEqual` compares them by value:
+The `comparable`-constrained pair (`EqualTo`/`ExpectT`) can't even be called with a slice or map — that's a compile error, not a runtime surprise. But for structs containing pointer fields, `==` compares the pointer values themselves, while `reflect.DeepEqual` can recursively compare the values they point to:
 
 ```go
 type withPtr struct{ N *int }
@@ -110,7 +110,7 @@ x == y                    // false — different pointers
 reflect.DeepEqual(x, y)   // true  — same pointed-to value
 ```
 
-So `EqualTo(ctx, x, y)` fails while `ctx.Expect(x).ToEqual(y)` passes, for the exact same `x`/`y`. This is the tradeoff: pick `EqualTo`/`ExpectT` for the zero-allocation, no-reflection fast path when your type's `==` already means what you want (primitives, or plain value structs with no pointer/interface fields); pick `ctx.Expect(...).ToEqual(...)` when you need value-based deep equality for structs, slices, or maps.
+So `EqualTo(ctx, x, y)` fails while `ctx.Expect(x).ToEqual(y)` passes, for the exact same `x`/`y`. This is the tradeoff: pick `EqualTo`/`ExpectT` for the zero-allocation, no-reflection fast path when your type's `==` already means what you want (primitives, or plain value structs with no pointer fields); pick `ctx.Expect(...).ToEqual(...)` when you need value-based deep equality for structs, slices, or maps.
 
 ## Example
 

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -89,6 +89,29 @@ ctx.Expect(value).To(specs.Equal(expected))
 
 `ExpectT(ctx, x).ToEqual(y)` is the preferred form for typed equality; it avoids matcher allocations.
 
+### Equality semantics differ between the three `ToEqual`-shaped APIs — by design
+
+`EqualTo`, `ExpectT(ctx, x).ToEqual(y)`, and `ctx.Expect(x).ToEqual(y)` do not always agree on equal-looking values, because they trade off differently between speed and generality:
+
+| API | Constraint | Comparison |
+|---|---|---|
+| `EqualTo(ctx, actual, expected)` | `T comparable` (compile-time) | Go's `==`, always. No reflection. |
+| `ExpectT(ctx, x).ToEqual(y)` | `T comparable` (compile-time) | Go's `==`, always. No reflection. |
+| `ctx.Expect(x).ToEqual(y)` | `any` | `==` for `int`/`string`/`bool`/`int64`/`float64`/`uint` (fast path), `reflect.DeepEqual` for everything else. |
+
+The `comparable`-constrained pair (`EqualTo`/`ExpectT`) can't even be called with a slice or map — that's a compile error, not a runtime surprise. But for a struct (or any type) that holds a pointer, interface, or other reference field, `==` compares those fields by identity while `reflect.DeepEqual` compares them by value:
+
+```go
+type withPtr struct{ N *int }
+a, b := 5, 5
+x, y := withPtr{&a}, withPtr{&b}
+
+x == y                    // false — different pointers
+reflect.DeepEqual(x, y)   // true  — same pointed-to value
+```
+
+So `EqualTo(ctx, x, y)` fails while `ctx.Expect(x).ToEqual(y)` passes, for the exact same `x`/`y`. This is the tradeoff: pick `EqualTo`/`ExpectT` for the zero-allocation, no-reflection fast path when your type's `==` already means what you want (primitives, or plain value structs with no pointer/interface fields); pick `ctx.Expect(...).ToEqual(...)` when you need value-based deep equality for structs, slices, or maps.
+
 ## Example
 
 ```go

--- a/specs/context.go
+++ b/specs/context.go
@@ -134,9 +134,9 @@ type expectT[T comparable] struct{ e *Expectation }
 // EqualTo asserts that actual equals expected. Zero alloc; single comparison, no type switch, no reflection.
 // Helper() is only called on failure so the fast path avoids runtime.Callers().
 //
-// Compares with Go's == (never reflect.DeepEqual): for a struct holding a pointer/interface field,
-// that compares identity, not the pointed-to value — unlike ctx.Expect(x).ToEqual(y)'s reflect
-// fallback for non-primitive types. See "Equality semantics" in docs/DSL.md.
+// Compares with Go's == (never reflect.DeepEqual): for a struct holding a pointer field, that
+// compares the pointer value itself, not the pointed-to value — unlike ctx.Expect(x).ToEqual(y)'s
+// reflect fallback for non-primitive types. See "Equality semantics" in docs/DSL.md.
 //
 // Example: specs.EqualTo(ctx, 42, 42) or specs.EqualTo(ctx, "got", "got")
 func EqualTo[T comparable](c *Context, actual, expected T) {

--- a/specs/context.go
+++ b/specs/context.go
@@ -134,6 +134,10 @@ type expectT[T comparable] struct{ e *Expectation }
 // EqualTo asserts that actual equals expected. Zero alloc; single comparison, no type switch, no reflection.
 // Helper() is only called on failure so the fast path avoids runtime.Callers().
 //
+// Compares with Go's == (never reflect.DeepEqual): for a struct holding a pointer/interface field,
+// that compares identity, not the pointed-to value — unlike ctx.Expect(x).ToEqual(y)'s reflect
+// fallback for non-primitive types. See "Equality semantics" in docs/DSL.md.
+//
 // Example: specs.EqualTo(ctx, 42, 42) or specs.EqualTo(ctx, "got", "got")
 func EqualTo[T comparable](c *Context, actual, expected T) {
 	if c == nil || c.backend == nil {
@@ -153,6 +157,8 @@ func EqualTo[T comparable](c *Context, actual, expected T) {
 // ExpectT returns a typed expectation for comparable types. Zero allocations (reuses pooled Expectation).
 // ToEqual(expected) does one type assertion and direct comparison; inlineable.
 //
+// Same == comparison as EqualTo (see its doc comment) — not reflect.DeepEqual.
+//
 // Example: specs.ExpectT(ctx, 42).ToEqual(42) or specs.ExpectT(ctx, true).To(specs.BeTrue())
 func ExpectT[T comparable](c *Context, v T) expectT[T] {
 	e := expectationPool.Get().(*Expectation)
@@ -161,7 +167,8 @@ func ExpectT[T comparable](c *Context, v T) expectT[T] {
 	return expectT[T]{e: e}
 }
 
-// ToEqual asserts that the value equals expected. No reflection; inlineable. Helper() only on failure.
+// ToEqual asserts that the value equals expected using ==, not reflect.DeepEqual (see ExpectT's doc
+// comment). No reflection; inlineable. Helper() only on failure.
 func (x expectT[T]) ToEqual(expected T) {
 	e := x.e
 	if e == nil {
@@ -263,6 +270,12 @@ func (e *Expectation) To(m Matcher) {
 }
 
 // ToEqual asserts that the actual value equals expected (fast path for benchmarks). Helper() only on failure.
+//
+// Unlike EqualTo/ExpectT.ToEqual (which always use ==), this uses == only for a fast-path set of
+// primitive types (int, string, bool, int64, float64, uint) and falls back to reflect.DeepEqual for
+// everything else — including other primitives like int32/float32/uint64, and any struct, slice, or
+// map. That makes this the right choice when you need value-based equality for non-primitive types;
+// see "Equality semantics" in docs/DSL.md for why this differs from EqualTo/ExpectT.
 func (e *Expectation) ToEqual(expected any) {
 	if e == nil {
 		return
@@ -431,4 +444,3 @@ func runAfterHooks(ctx *Context, fixtures []Fixture) {
 		}
 	}
 }
-

--- a/specs/equality_semantics_test.go
+++ b/specs/equality_semantics_test.go
@@ -1,0 +1,38 @@
+package specs
+
+// equality_semantics_test.go locks in the documented equality-semantics divergence between
+// EqualTo/ExpectT.ToEqual (always ==) and Expectation.ToEqual (== fast path, reflect.DeepEqual
+// fallback for everything else). See "Equality semantics" in docs/DSL.md and issue #8. This is a
+// deliberate design tradeoff (speed vs. value-based equality for non-primitive types), not a bug —
+// these tests exist so a future change to either comparison can't silently make them agree (or
+// disagree differently) without a test failing to call it out.
+
+import "testing"
+
+type equalityWithPtr struct{ N *int }
+
+// TestEqualitySemantics_PointerStructDivergesByDesign verifies that EqualTo (==, pointer identity)
+// and ctx.Expect(...).ToEqual (reflect.DeepEqual fallback, value equality) disagree for the exact
+// same logical values when a struct holds a pointer field — by design, not a bug.
+func TestEqualitySemantics_PointerStructDivergesByDesign(t *testing.T) {
+	a, b := 5, 5
+	x, y := equalityWithPtr{N: &a}, equalityWithPtr{N: &b}
+
+	eqToBackend := &capturingBackend{}
+	EqualTo(&Context{backend: eqToBackend}, x, y)
+	if !eqToBackend.failed {
+		t.Error("expected EqualTo to fail: == compares pointer identity, and x.N != y.N")
+	}
+
+	expectTBackend := &capturingBackend{}
+	ExpectT(&Context{backend: expectTBackend}, x).ToEqual(y)
+	if !expectTBackend.failed {
+		t.Error("expected ExpectT(...).ToEqual to fail the same way as EqualTo — same == semantics")
+	}
+
+	expectBackend := &capturingBackend{}
+	(&Context{backend: expectBackend}).Expect(x).ToEqual(y)
+	if expectBackend.failed {
+		t.Errorf("expected ctx.Expect(...).ToEqual to pass via reflect.DeepEqual, got failure: %q", expectBackend.message)
+	}
+}


### PR DESCRIPTION
## Summary
- \`EqualTo\`, \`ExpectT(ctx, x).ToEqual(y)\`, and \`ctx.Expect(x).ToEqual(y)\` don't always agree: the `comparable`-constrained pair always uses \`==\`, while \`Expectation.ToEqual\` uses \`==\` for a fast-path set of primitives (\`int\`/\`string\`/\`bool\`/\`int64\`/\`float64\`/\`uint\`) and falls back to \`reflect.DeepEqual\` for everything else.
- Verified this is a real, demonstrable divergence, not just theoretical: for a struct holding a pointer field, \`==\` compares identity while \`DeepEqual\` compares the pointed-to value — so \`EqualTo(ctx, x, y)\` and \`ctx.Expect(x).ToEqual(y)\` can give opposite results for the exact same logical \`x\`/\`y\`.
- Went with **documenting** the tradeoff rather than **consolidating**: \`EqualTo\`/\`ExpectT\`'s whole purpose is the zero-alloc, no-reflection fast path (and \`comparable\` already rules out slices/maps at compile time), while \`Expectation.ToEqual\`'s \`any\`-based \`DeepEqual\` fallback is what makes it usable for structs/slices/maps at all — unifying them would cost one side its guarantees.
- Each function's doc comment now states its exact semantics, \`docs/DSL.md\` gets a worked example with a comparison table, and a new test (\`TestEqualitySemantics_PointerStructDivergesByDesign\`) locks in the divergence so it can't silently change later.

Fixes #8

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -race\`
- [x] New test demonstrates \`EqualTo\`/\`ExpectT\` fail while \`Expectation.ToEqual\` passes for the same pointer-holding struct values