### PR TITLE
docs(specs): clarify the two independent mutation strategies

### DIFF
--- a/specs/explorer_coverage.go
+++ b/specs/explorer_coverage.go
@@ -3,7 +3,13 @@ package specs
 // CoverageExplorer learns from execution-path coverage (branch sampling via assertions).
 // seenCoverageHashes is maintained in the Coverage bitmap; when Feedback reports new edges,
 // the input is stored in the corpus. NextInput returns random input when corpus is empty,
-// otherwise a mutation of a random corpus entry (Mutator: +1, -1, bit flip, swap, boundary).
+// otherwise a mutation of a random corpus entry via Mutator.Mutate: +1/-1/×2/÷2/bit-flip/nearby
+// for a ranged int or int64 dimension (see Mutator.MutateInt); other dimensions (bool, discrete,
+// unranged int) are left unchanged — see Mutator.Mutate's doc comment and #9's follow-up issue.
+//
+// This is a different mutation strategy from the one PathSpec.Explore(n) uses (PathGenerator's own
+// unexported mutate, which does mutate bool/discrete dimensions) — see Mutator.Mutate's doc comment
+// for why the two exist and aren't meant to be interchangeable.
 type CoverageExplorer struct {
 	corpus   *Corpus
 	mutator  *Mutator

--- a/specs/mutation_strategy_test.go
+++ b/specs/mutation_strategy_test.go
@@ -1,0 +1,28 @@
+package specs
+
+// mutation_strategy_test.go locks in the documented divergence between the two independently-
+// reachable mutation strategies for property-based exploration (see #9, and the doc comments on
+// Mutator.Mutate and PathGenerator.mutate): Mutator.Mutate (used by PathSpec.ExploreCoverage/
+// ExploreSmart) is a no-op for a bool dimension, while PathGenerator.mutate (used by
+// PathSpec.Explore) always mutates something — for bool, it negates. With a single bool dimension,
+// the dimension pick is deterministic (there's nothing else to pick), so this needs no seeding
+// tricks to be reliable.
+
+import "testing"
+
+func TestMutationStrategies_DivergeOnBoolDimension(t *testing.T) {
+	// exploreIterations > 0 puts the generator in ExplorationGuided mode, which is what allocates
+	// g.rng — PathGenerator.mutate (unlike Mutator.Mutate, which carries its own rng) uses it.
+	gen := newPathGenerator([]PathVar{{Name: "flag", Values: []any{true, false}}}, nil, 0, 1, true, 1, 0, 0)
+	input := gen.PathValuesWith(map[string]any{"flag": true})
+
+	out := NewMutator(1).Mutate(gen, input)
+	if out.values[0] != true {
+		t.Errorf("Mutator.Mutate: expected the bool dimension to stay unchanged (documented no-op for non-int dimensions), got %v", out.values[0])
+	}
+
+	genMutated := gen.mutate(input)
+	if genMutated.values[0] != false {
+		t.Errorf("PathGenerator.mutate: expected the bool dimension to be negated to false, got %v", genMutated.values[0])
+	}
+}

--- a/specs/mutation_strategy_test.go
+++ b/specs/mutation_strategy_test.go
@@ -4,9 +4,9 @@ package specs
 // reachable mutation strategies for property-based exploration (see #9, and the doc comments on
 // Mutator.Mutate and PathGenerator.mutate): Mutator.Mutate (used by PathSpec.ExploreCoverage/
 // ExploreSmart) is a no-op for a bool dimension, while PathGenerator.mutate (used by
-// PathSpec.Explore) always mutates something — for bool, it negates. With a single bool dimension,
-// the dimension pick is deterministic (there's nothing else to pick), so this needs no seeding
-// tricks to be reliable.
+// PathSpec.Explore) unconditionally negates a bool dimension. With a single bool dimension, the
+// dimension pick is deterministic (there's nothing else to pick), so this needs no seeding tricks
+// to be reliable.
 
 import "testing"
 

--- a/specs/mutator.go
+++ b/specs/mutator.go
@@ -67,10 +67,11 @@ func (m *Mutator) MutateInt(v, min, max int) int {
 //
 // This is the mutation strategy behind PathSpec.ExploreCoverage/ExploreSmart (via CoverageExplorer/
 // SmartExplorer). PathSpec.Explore uses a different, unexported strategy (PathGenerator.mutate in
-// path_generator.go) that does mutate bool and discrete dimensions, at the cost of not sharing this
-// type's int-mutation operators (bit-flip, ×2/÷2, etc. — see MutateInt). The two aren't meant to be
-// interchangeable: each backs a distinct public exploration mode, evolved independently rather than
-// consolidated, per the discussion on #9.
+// path_generator.go) that has an explicit mutation path for bool and discrete dimensions too (bool
+// is always flipped; a discrete re-pick may coincidentally land on the same value), at the cost of
+// not sharing this type's int-mutation operators (bit-flip, ×2/÷2, etc. — see MutateInt). The two
+// aren't meant to be interchangeable: each backs a distinct public exploration mode, evolved
+// independently rather than consolidated, per the discussion on #9.
 func (m *Mutator) Mutate(gen *PathGenerator, p PathValues) PathValues {
 	if m == nil || m.rng == nil || gen == nil {
 		return p.clone()

--- a/specs/mutator.go
+++ b/specs/mutator.go
@@ -60,8 +60,17 @@ func (m *Mutator) MutateInt(v, min, max int) int {
 }
 
 // Mutate returns a clone of p with one random dimension mutated.
-// For int dimensions with a range, MutateInt is used and the result is clamped to generator bounds.
-// Other dimensions are left unchanged.
+// For int/int64 dimensions with a range, MutateInt is used and the result is clamped to generator
+// bounds. Other dimensions (bool, discrete values, unranged int/int64) are left unchanged — this
+// call can be a no-op if the randomly picked dimension isn't a ranged int/int64. See #9's follow-up
+// issue for tracking that gap.
+//
+// This is the mutation strategy behind PathSpec.ExploreCoverage/ExploreSmart (via CoverageExplorer/
+// SmartExplorer). PathSpec.Explore uses a different, unexported strategy (PathGenerator.mutate in
+// path_generator.go) that does mutate bool and discrete dimensions, at the cost of not sharing this
+// type's int-mutation operators (bit-flip, ×2/÷2, etc. — see MutateInt). The two aren't meant to be
+// interchangeable: each backs a distinct public exploration mode, evolved independently rather than
+// consolidated, per the discussion on #9.
 func (m *Mutator) Mutate(gen *PathGenerator, p PathValues) PathValues {
 	if m == nil || m.rng == nil || gen == nil {
 		return p.clone()

--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -408,6 +408,14 @@ func (g *PathGenerator) RandomInput(rng *rand.Rand) PathValues {
 	return pv
 }
 
+// mutate returns a clone of input with one random dimension mutated: int gets +1/-1/mid-range (if
+// ranged)/a random discrete value/full re-randomization, bool gets negated, and any other type is
+// fully re-randomized via dim.randomValue. Unlike Mutator.Mutate (mutator.go), no dimension is ever
+// left unchanged — but it also lacks Mutator's richer int operators (bit-flip, ×2/÷2, clamping).
+//
+// This is PathSpec.Explore's mutation strategy (via runExploration below); ExploreCoverage/
+// ExploreSmart use Mutator.Mutate instead. See Mutator.Mutate's doc comment and #9 for why these
+// are two independently-evolved strategies rather than one shared implementation.
 func (g *PathGenerator) mutate(input PathValues) PathValues {
 	mutated := input.clone()
 	if len(g.dims) == 0 {

--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -410,8 +410,12 @@ func (g *PathGenerator) RandomInput(rng *rand.Rand) PathValues {
 
 // mutate returns a clone of input with one random dimension mutated: int gets +1/-1/mid-range (if
 // ranged)/a random discrete value/full re-randomization, bool gets negated, and any other type is
-// fully re-randomized via dim.randomValue. Unlike Mutator.Mutate (mutator.go), no dimension is ever
-// left unchanged — but it also lacks Mutator's richer int operators (bit-flip, ×2/÷2, clamping).
+// fully re-randomized via dim.randomValue. Unlike Mutator.Mutate (mutator.go), every dimension type
+// has an explicit mutation path — bool and discrete values aren't left unsupported. That doesn't
+// guarantee the result differs from the input, though: the discrete-value and dim.randomValue paths
+// pick from the dimension's full value set without excluding the current value, so re-picking the
+// same value by chance is possible (unlike, say, bool's unconditional negation). It also lacks
+// Mutator's richer int operators (bit-flip, ×2/÷2, clamping).
 //
 // This is PathSpec.Explore's mutation strategy (via runExploration below); ExploreCoverage/
 // ExploreSmart use Mutator.Mutate instead. See Mutator.Mutate's doc comment and #9 for why these


### PR DESCRIPTION
## Summary
- Answers #9's core question with evidence, not guesswork: **neither** `Mutator.Mutate` nor `PathGenerator.mutate` is dead code. Both are live, reached from different public entry points — `PathSpec.ExploreCoverage`/`ExploreSmart` use `Mutator.Mutate` (via `CoverageExplorer`/`SmartExplorer`), `PathSpec.Explore` uses `PathGenerator.mutate` (via `runExploration`, mode `ExplorationGuided`).
- Documented why they're intentionally two separate strategies rather than one shared implementation: `Mutator.Mutate` has richer int operators (bit-flip, ×2/÷2, clamping) but only for ranged int/int64; `PathGenerator.mutate` has an explicit mutation path for every dimension type (negates bool, re-picks discrete values) but lacks those int operators — note re-picking a discrete value doesn't guarantee it differs from the current one, only bool's negation is guaranteed to change.
- Fixed `explorer_coverage.go`'s doc comment, which claimed "+1, -1, bit flip, swap, boundary" — verified via repo-wide grep that no "swap" operation exists anywhere; that text was stale/aspirational.
- New test `TestMutationStrategies_DivergeOnBoolDimension` locks in the real, current divergence.
- Along the way, found a genuine weakness while comparing the two: `Mutator.Mutate` (the strategy behind the two more advanced explorer modes) is a documented no-op for bool/discrete/unranged-int dimensions — worse than `PathGenerator.mutate` for those cases, and not what its own doc comment implied. That's a real behavior gap in the fuzzing engine, not a documentation issue, so it's tracked separately in #41 rather than bundled into this doc-clarity PR.

Fixes #9

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race`
- [x] New test demonstrates the exact divergence being documented