### PR TITLE
docs(specs): fix RunShard doc comment and note sharding limitation

### DIFF
--- a/docs/EXECUTION_MODEL.md
+++ b/docs/EXECUTION_MODEL.md
@@ -110,3 +110,11 @@ flowchart TD
 ```
 
 The builder groups parallel specs into one step; the runner executes that step (e.g. by launching goroutines and waiting). So from the runner’s perspective, a parallel group is still just one step in the flat plan.
+
+---
+
+## CI sharding
+
+`RunShard` splits a compiled `Program` across CI shards by hook group, not by individual spec: specs sharing a `BeforeEach`/`AfterEach` are compiled into one group, and whole groups are assigned to shards by `gi % shardCount == shardIndex`. If a suite has many specs under one shared hook, that entire group lands on a single shard.
+
+**Known limitation:** this can produce uneven shard runtimes when hook groups are large or unevenly sized, since balancing happens at the group level rather than the individual-spec level. Balancing by spec count is tracked separately and deferred post-v1.0.0.

--- a/specs/scheduler.go
+++ b/specs/scheduler.go
@@ -128,9 +128,13 @@ func reportFailures(tb failureReporter, results []string) {
 	}
 }
 
-// RunShard runs a shard of the compiled Program for CI. Group indices are assigned to shards
-// by gi % shardCount == shardIndex. shardCount must be > 0 and 0 <= shardIndex < shardCount.
-// Allocation happens once to build the shard's Program; the runner loop is allocation-free.
+// RunShard runs a shard of the compiled Program for CI. Sharding operates on already-coalesced
+// hook groups (specs sharing a BeforeEach/AfterEach are compiled into one group), not individual
+// specs: group indices are assigned to shards by gi % shardCount == shardIndex. A suite with many
+// specs under one shared hook lands its whole group on a single shard, so shard runtimes can be
+// uneven when hook groups are large or unevenly sized. shardCount must be > 0 and
+// 0 <= shardIndex < shardCount. Allocation happens once to build the shard's Program; the runner
+// loop is allocation-free.
 func RunShard(program *Program, tb testing.TB, shardIndex, shardCount int) {
 	if program == nil || tb == nil {
 		return


### PR DESCRIPTION
## Summary
- `RunShard`'s doc comment claimed spec-level balanced sharding; the implementation shards already-coalesced hook groups instead
- Fixed the doc comment on `specs/scheduler.go` to describe the actual group-level behavior and its uneven-runtime tradeoff
- Added a "CI sharding" section to `docs/EXECUTION_MODEL.md` documenting the limitation for CI users, referencing the deferred (post-v1.0.0) spec-level balancing work

Fixes #7

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Docs-only change to `specs/scheduler.go` comment + `docs/EXECUTION_MODEL.md`; no behavior change