### PR TITLE
feat(specs): add bounded proposal controller

### DIFF
--- a/specs/exploration_controller.go
+++ b/specs/exploration_controller.go
@@ -1,0 +1,121 @@
+package specs
+
+import "context"
+
+// proposalTerminal identifies why a bounded generated run stopped.
+type proposalTerminal uint8
+
+const (
+	proposalTerminalExhausted proposalTerminal = iota
+	proposalTerminalAttemptsBudget
+	proposalTerminalAcceptedBudget
+	proposalTerminalRejectedCap
+	proposalTerminalCanceled
+	proposalTerminalDeadline
+	proposalTerminalFirstFailure
+)
+
+// proposalCandidate records one proposed path. AcceptedIndex is zero for rejections.
+type proposalCandidate struct {
+	Values        PathValues
+	AttemptIndex  int
+	AcceptedIndex int
+	Accepted      bool
+}
+
+// proposalControllerResult is the ordered, internal result of a bounded run.
+type proposalControllerResult struct {
+	Seed         int64
+	Terminal     proposalTerminal
+	Attempts     int
+	Accepted     int
+	Rejections   int
+	Candidates   []proposalCandidate
+	Feedback     []proposalCandidate
+	FirstFailure proposalCandidate
+	HasFailure   bool
+}
+
+// proposalControllerConfig keeps proposal, execution, and feedback independent.
+type proposalControllerConfig struct {
+	Seed          int64
+	MaxAttempts   int
+	MaxAccepted   int
+	MaxRejections int
+	Propose       func() (PathValues, bool)
+	Accept        func(PathValues) bool
+	Execute       func(proposalCandidate) bool
+	AdmitFeedback func(proposalCandidate)
+}
+
+type proposalController struct{ config proposalControllerConfig }
+
+func newProposalController(config proposalControllerConfig) proposalController {
+	return proposalController{config: config}
+}
+
+// Run evaluates proposals in order. It deliberately has no parallel execution option.
+func (c proposalController) Run(ctx context.Context) proposalControllerResult {
+	result := proposalControllerResult{Seed: c.config.Seed}
+	for {
+		if terminal, done := proposalContextTerminal(ctx); done {
+			result.Terminal = terminal
+			return result
+		}
+		if c.config.MaxAttempts > 0 && result.Attempts >= c.config.MaxAttempts {
+			result.Terminal = proposalTerminalAttemptsBudget
+			return result
+		}
+		if c.config.MaxAccepted > 0 && result.Accepted >= c.config.MaxAccepted {
+			result.Terminal = proposalTerminalAcceptedBudget
+			return result
+		}
+		if c.config.MaxRejections > 0 && result.Rejections >= c.config.MaxRejections {
+			result.Terminal = proposalTerminalRejectedCap
+			return result
+		}
+		if c.config.Propose == nil {
+			result.Terminal = proposalTerminalExhausted
+			return result
+		}
+
+		values, ok := c.config.Propose()
+		if !ok {
+			result.Terminal = proposalTerminalExhausted
+			return result
+		}
+		result.Attempts++
+		candidate := proposalCandidate{Values: values.clone(), AttemptIndex: result.Attempts}
+		candidate.Accepted = c.config.Accept == nil || c.config.Accept(values)
+		if !candidate.Accepted {
+			result.Rejections++
+			result.Candidates = append(result.Candidates, candidate)
+			continue
+		}
+
+		result.Accepted++
+		candidate.AcceptedIndex = result.Accepted
+		result.Candidates = append(result.Candidates, candidate)
+		passed := c.config.Execute == nil || c.config.Execute(candidate)
+		if !passed {
+			result.Terminal = proposalTerminalFirstFailure
+			result.FirstFailure = candidate
+			result.HasFailure = true
+			return result
+		}
+		if c.config.AdmitFeedback != nil {
+			c.config.AdmitFeedback(candidate)
+		}
+		result.Feedback = append(result.Feedback, candidate)
+	}
+}
+
+func proposalContextTerminal(ctx context.Context) (proposalTerminal, bool) {
+	if ctx == nil || ctx.Err() == nil {
+		return 0, false
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return proposalTerminalDeadline, true
+	}
+	return proposalTerminalCanceled, true
+}

--- a/specs/exploration_controller_test.go
+++ b/specs/exploration_controller_test.go
@@ -1,0 +1,141 @@
+package specs
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestProposalControllerBoundsAndIndices(t *testing.T) {
+	t.Run("accepted budget retains monotonic attempt and accepted indices", func(t *testing.T) {
+		candidates := []PathValues{pathValue(1), pathValue(2), pathValue(3)}
+		result := newProposalController(proposalControllerConfig{
+			Seed:        42,
+			MaxAttempts: 3,
+			MaxAccepted: 2,
+			Propose: func() (PathValues, bool) {
+				candidate := candidates[0]
+				candidates = candidates[1:]
+				return candidate, true
+			},
+			Accept: func(PathValues) bool { return true },
+			Execute: func(candidate proposalCandidate) bool {
+				return candidate.AttemptIndex == candidate.AcceptedIndex
+			},
+		}).Run(context.Background())
+
+		if result.Terminal != proposalTerminalAcceptedBudget || result.Seed != 42 {
+			t.Fatalf("terminal=%v seed=%d, want accepted budget and 42", result.Terminal, result.Seed)
+		}
+		if got := candidateIndices(result.Candidates); !reflect.DeepEqual(got, [][2]int{{1, 1}, {2, 2}}) {
+			t.Fatalf("indices=%v, want [[1 1] [2 2]]", got)
+		}
+	})
+
+	t.Run("restrictive filter stops at rejection cap", func(t *testing.T) {
+		result := newProposalController(proposalControllerConfig{
+			MaxAttempts:   9,
+			MaxRejections: 2,
+			Propose:       func() (PathValues, bool) { return pathValue(1), true },
+			Accept:        func(PathValues) bool { return false },
+		}).Run(context.Background())
+		if result.Terminal != proposalTerminalRejectedCap || result.Attempts != 2 || result.Rejections != 2 {
+			t.Fatalf("result=%+v, want two capped rejections", result)
+		}
+	})
+}
+
+func TestProposalControllerCancellationAndDeadline(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := newProposalController(proposalControllerConfig{Propose: func() (PathValues, bool) {
+		t.Fatal("proposal must not run after cancellation")
+		return PathValues{}, false
+	}}).Run(ctx)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal=%v, want canceled", result.Terminal)
+	}
+
+	deadline, deadlineCancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer deadlineCancel()
+	result = newProposalController(proposalControllerConfig{}).Run(deadline)
+	if result.Terminal != proposalTerminalDeadline {
+		t.Fatalf("terminal=%v, want deadline", result.Terminal)
+	}
+}
+
+func TestProposalControllerDeterministicOrderingAndSequentialExecution(t *testing.T) {
+	run := func() proposalControllerResult {
+		candidates := []PathValues{pathValue(3), pathValue(5), pathValue(7)}
+		feedback := make([]int, 0, 3)
+		return newProposalController(proposalControllerConfig{
+			Seed:        7,
+			MaxAttempts: 3,
+			Propose: func() (PathValues, bool) {
+				candidate := candidates[0]
+				candidates = candidates[1:]
+				return candidate, true
+			},
+			Accept:        func(PathValues) bool { return true },
+			Execute:       func(candidate proposalCandidate) bool { return candidate.Values.Int("value") != 5 },
+			AdmitFeedback: func(candidate proposalCandidate) { feedback = append(feedback, candidate.Values.Int("value")) },
+		}).Run(context.Background())
+	}
+
+	first, second := run(), run()
+	if first.Terminal != proposalTerminalFirstFailure || !reflect.DeepEqual(first, second) {
+		t.Fatalf("fixed-seed results differ or did not stop at first failure: first=%+v second=%+v", first, second)
+	}
+	if got := candidateValues(first.Candidates); !reflect.DeepEqual(got, []int{3, 5}) {
+		t.Fatalf("candidate order=%v, want [3 5]", got)
+	}
+	if first.FirstFailure.AcceptedIndex != 2 || !reflect.DeepEqual(candidateValues(first.Feedback), []int{3}) {
+		t.Fatalf("first failure/feedback=%+v/%v, want accepted index 2 and [3]", first.FirstFailure, candidateValues(first.Feedback))
+	}
+}
+
+func TestProposalControllerHasNoParallelExecutionOption(t *testing.T) {
+	active, maximum := 0, 0
+	result := newProposalController(proposalControllerConfig{
+		MaxAttempts: 2,
+		Propose: func() (PathValues, bool) {
+			if active == 0 {
+				return pathValue(1), true
+			}
+			return pathValue(2), true
+		},
+		Accept: func(PathValues) bool { return true },
+		Execute: func(proposalCandidate) bool {
+			active++
+			if active > maximum {
+				maximum = active
+			}
+			active--
+			return true
+		},
+	}).Run(context.Background())
+	if result.Terminal != proposalTerminalAttemptsBudget || maximum != 1 {
+		t.Fatalf("terminal=%v maximum concurrent executions=%d, want attempts budget and 1", result.Terminal, maximum)
+	}
+}
+
+func pathValue(value int) PathValues {
+	return PathValues{values: []any{value}, present: []bool{true}, index: map[string]int{"value": 0}}
+}
+
+func candidateIndices(candidates []proposalCandidate) [][2]int {
+	indices := make([][2]int, len(candidates))
+	for i, candidate := range candidates {
+		indices[i] = [2]int{candidate.AttemptIndex, candidate.AcceptedIndex}
+	}
+	return indices
+}
+
+func candidateValues(candidates []proposalCandidate) []int {
+	values := make([]int, len(candidates))
+	for i, candidate := range candidates {
+		values[i] = candidate.Values.Int("value")
+	}
+	return values
+}


### PR DESCRIPTION
Part of #43

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds only the internal bounded proposal controller and deterministic tests for proposal budgets, terminal conditions, ordering, feedback, and sequential execution.
- Real generated `Paths` dispatch is intentionally out of scope and remains for PR2B.

## Changes

| File | Change |
|------|--------|
| `specs/exploration_controller.go` | Adds the internal bounded, deterministic, sequential proposal controller. |
| `specs/exploration_controller_test.go` | Adds deterministic coverage for budgets, cancellation/deadline, ordering, first failure, feedback, and no parallel execution. |

## Chain Context

- Strategy: Feature Branch Chain
- Start: tracker `feat/automatic-spec-exploration`
- Current boundary: internal bounded proposal controller and its deterministic tests (262 additions; no deletions).
- Dependency: PR2B will target this branch to wire real generated `Paths` dispatch.
- Out of scope: production dispatch integration.

```text
feat/automatic-spec-exploration (tracker)
  └── 📍 feat/automatic-spec-exploration-pr2a (this PR)
        └── PR2B: real generated Paths dispatch
```

## Test Plan

- [x] `go test ./specs -run "^TestProposalController" -count=1`
- [x] `make test`
- [x] No shell scripts were modified; shellcheck is not applicable.

## Contributor Checklist

- [x] References approved issue `#43` without resolving it.
- [x] Added exactly one `type:*` label (`type:feature`).
- [x] Shellcheck is not applicable because no shell scripts were modified.
- [x] Required delivery skills were loaded in the delivery agent.
- [x] Documentation is not required because this is internal-only and real dispatch remains for PR2B.
- [x] Uses a Conventional Commit title and commit (`feat(specs): add bounded proposal controller`).
- [x] Contains no `Co-Authored-By` trailers.