### PR TITLE
feat(specs): dispatch generated paths through controller

### DIFF
--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -2,10 +2,12 @@
 package specs
 
 import (
+	"context"
 	"io"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pablogore/go-specs/report"
 )
@@ -150,28 +152,78 @@ type CompiledSuite struct {
 
 // Run executes all specs in the plan. Uses one context from the pool per spec (or per path iteration).
 func (s *CompiledSuite) Run(tb testing.TB) {
+	s.run(tb, nil)
+}
+
+func (s *CompiledSuite) run(tb testing.TB, runCtx context.Context) []proposalControllerResult {
 	if s == nil || s.Plan == nil || tb == nil || len(s.Plan.ProgramStart) == 0 {
-		return
+		return nil
+	}
+	if runCtx == nil {
+		var cancel context.CancelFunc
+		runCtx, cancel = executionContext(tb)
+		defer cancel()
 	}
 	backend := asTestBackend(tb)
 	defer putTestBackend(backend)
 	rep := report.New(io.Discard)
-	runPlanFlatNoSubtests(backend, rep, s.Plan)
+	return runPlanFlatNoSubtests(runCtx, backend, rep, s.Plan)
 }
 
-func runPlanFlatNoSubtests(backend testBackend, rep *report.Reporter, plan *ExecutionPlan) {
-	for i := 0; i < len(plan.ProgramStart); i++ {
-		runExecution(backend, rep, plan, i)
+func executionContext(tb testing.TB) (context.Context, context.CancelFunc) {
+	ctx := context.Background()
+	if contextual, ok := tb.(interface{ Context() context.Context }); ok && contextual.Context() != nil {
+		ctx = contextual.Context()
 	}
+	if timed, ok := tb.(interface{ Deadline() (time.Time, bool) }); ok {
+		if deadline, ok := timed.Deadline(); ok {
+			return context.WithDeadline(ctx, deadline)
+		}
+	}
+	return context.WithCancel(ctx)
 }
 
-func runExecution(backend testBackend, rep *report.Reporter, plan *ExecutionPlan, i int) {
+func runPlanFlatNoSubtests(runCtx context.Context, backend testBackend, rep *report.Reporter, plan *ExecutionPlan) []proposalControllerResult {
+	results := make([]proposalControllerResult, 0, len(plan.ProgramStart))
+	for i := 0; i < len(plan.ProgramStart); i++ {
+		results = append(results, runExecutionContext(runCtx, backend, rep, plan, i))
+	}
+	return results
+}
+
+func runExecution(backend testBackend, rep *report.Reporter, plan *ExecutionPlan, i int) proposalControllerResult {
+	return runExecutionContext(context.Background(), backend, rep, plan, i)
+}
+
+func runExecutionContext(runCtx context.Context, backend testBackend, rep *report.Reporter, plan *ExecutionPlan, i int) proposalControllerResult {
 	start := plan.ProgramStart[i]
 	length := plan.ProgramLen[i]
 	if start+length > len(plan.Instructions) {
-		return
+		return proposalControllerResult{}
 	}
 	program := plan.Instructions[start : start+length]
+	if i < len(plan.PathGens) && plan.PathGens[i] != nil {
+		paths := make([]PathValues, 0)
+		plan.PathGens[i].ForEach(func(path PathValues) { paths = append(paths, path.clone()) })
+		next := 0
+		result := newProposalController(proposalControllerConfig{
+			MaxAttempts:   len(paths),
+			MaxAccepted:   len(paths),
+			MaxRejections: len(paths),
+			Propose: func() (PathValues, bool) {
+				if next == len(paths) {
+					return PathValues{}, false
+				}
+				path := paths[next]
+				next++
+				return path, true
+			},
+			Execute: func(candidate proposalCandidate) bool {
+				return !runIsolatedCase(backend, program, candidate.Values).Failed
+			},
+		}).Run(runCtx)
+		return result
+	}
 	ctx := contextPool.Get().(*Context)
 	defer func() {
 		ctx.Reset(nil)
@@ -180,6 +232,7 @@ func runExecution(backend testBackend, rep *report.Reporter, plan *ExecutionPlan
 	ctx.Reset(backend)
 	ctx.SetPathValues(PathValues{})
 	runProgram(program, ctx, nil)
+	return proposalControllerResult{}
 }
 
 func runProgram(program []Instruction, ctx *Context, path *PathValues) {
@@ -194,7 +247,7 @@ func runProgram(program []Instruction, ctx *Context, path *PathValues) {
 }
 
 // isolatedCaseAbort lets a controlled backend stop one isolated case without
-// terminating the parent test. Generated dispatch does not use this boundary yet.
+// terminating the parent test.
 type isolatedCaseAbort struct{}
 
 type isolatedCaseResult struct {
@@ -204,9 +257,22 @@ type isolatedCaseResult struct {
 	ContextReset bool
 }
 
-// runIsolatedCase proves the lifecycle required before generated dispatch can be enabled.
-// It is intentionally not called by runExecution until the later dispatch slice.
+// runIsolatedCase executes real generated cases in a subtest so Fatal and FailNow
+// terminate only that case while preserving the parent test's failure semantics.
 func runIsolatedCase(backend testBackend, program []Instruction, path PathValues) (result isolatedCaseResult) {
+	if real, ok := backend.(*runnableBackend); ok {
+		real.Run("generated", func(tb testing.TB) {
+			caseBackend := asTestBackend(tb)
+			defer putTestBackend(caseBackend)
+			defer func() { result.Failed = result.Failed || tb.Failed() }()
+			result = runIsolatedCaseDirect(caseBackend, program, path)
+		})
+		return result
+	}
+	return runIsolatedCaseDirect(backend, program, path)
+}
+
+func runIsolatedCaseDirect(backend testBackend, program []Instruction, path PathValues) (result isolatedCaseResult) {
 	ctx := contextPool.Get().(*Context)
 	ctx.Reset(backend)
 	ctx.SetPathValues(path)

--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -202,7 +202,25 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 		return proposalControllerResult{}
 	}
 	program := plan.Instructions[start : start+length]
+	if i < len(plan.PathGens) && plan.PathGens[i] != nil && plan.PathGens[i].mode == CartesianMode {
+		gen := plan.PathGens[i]
+		seq := gen.sequence()
+		maxAttempts, maxAccepted, maxRejections := gen.bounds()
+		return newProposalController(proposalControllerConfig{
+			MaxAttempts:   maxAttempts,
+			MaxAccepted:   maxAccepted,
+			MaxRejections: maxRejections,
+			Propose:       seq.next,
+			Execute: func(candidate proposalCandidate) bool {
+				passed := !runIsolatedCase(backend, program, candidate.Values).Failed
+				seq.admitFeedback(candidate.Values, passed)
+				return passed
+			},
+		}).Run(runCtx)
+	}
 	if i < len(plan.PathGens) && plan.PathGens[i] != nil {
+		// Sample and Explore/ExploreCoverage/ExploreSmart still materialize via ForEach until a
+		// later change extends sequence()/bounds() to those strategies (see path_generator.go).
 		paths := make([]PathValues, 0)
 		plan.PathGens[i].ForEach(func(path PathValues) { paths = append(paths, path.clone()) })
 		next := 0

--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -212,9 +212,10 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 			MaxRejections: maxRejections,
 			Propose:       seq.next,
 			Execute: func(candidate proposalCandidate) bool {
-				passed := !runIsolatedCase(backend, program, candidate.Values).Failed
-				seq.admitFeedback(candidate.Values, passed)
-				return passed
+				return !runIsolatedCase(backend, program, candidate.Values).Failed
+			},
+			AdmitFeedback: func(feedback proposalFeedback) {
+				seq.admitFeedback(feedback.Candidate.Values, feedback.Passed)
 			},
 		}).Run(runCtx)
 	}

--- a/specs/execution_plan_test.go
+++ b/specs/execution_plan_test.go
@@ -190,6 +190,53 @@ func TestDescribePathsDispatchHonorsCancellationAndDeadline(t *testing.T) {
 	}
 }
 
+// TestRunExecutionContextCartesianDoesNotMaterializeUnderCancellation would fail against the old
+// ForEach-into-slice materialization: that approach generated every candidate (running filters
+// for all of them) before the controller ever got a chance to observe an already-canceled ctx.
+func TestRunExecutionContextCartesianDoesNotMaterializeUnderCancellation(t *testing.T) {
+	var considered int
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 999}}},
+		[]PathFilter{func(PathValues) bool { considered++; return true }}, 0, 0, false, 0, 0, 0)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { t.Fatal("body must not run") }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal = %v, want canceled", result.Terminal)
+	}
+	if considered != 0 {
+		t.Fatalf("candidates considered before the controller observed cancellation = %d, want 0", considered)
+	}
+}
+
+// TestRunExecutionContextCartesianStopsGeneratingOnCancelMidRun proves cancellation stops
+// generation immediately rather than only stopping dispatch of an already-generated candidate:
+// canceling from inside the first executed case must prevent a second candidate from ever being
+// proposed.
+func TestRunExecutionContextCartesianStopsGeneratingOnCancelMidRun(t *testing.T) {
+	var considered, executed int
+	ctx, cancel := context.WithCancel(context.Background())
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 999}}},
+		[]PathFilter{func(PathValues) bool { considered++; return true }}, 0, 0, false, 0, 0, 0)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { executed++; cancel() }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal = %v, want canceled", result.Terminal)
+	}
+	if executed != 1 {
+		t.Fatalf("executed = %d, want exactly 1 (canceled from inside the first case)", executed)
+	}
+	if considered != 1 {
+		t.Fatalf("candidates considered = %d, want 1 — generation must not run ahead of execution", considered)
+	}
+}
+
 func TestGeneratedFatalUsesRealSubtestBoundary(t *testing.T) {
 	if os.Getenv("GO_SPECS_FATAL_BOUNDARY_HELPER") == "1" {
 		var afterRuns int

--- a/specs/execution_plan_test.go
+++ b/specs/execution_plan_test.go
@@ -1,8 +1,13 @@
 package specs
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
+	"time"
 )
 
 type controlledBackend struct {
@@ -102,5 +107,112 @@ func TestOrdinaryItKeepsGoTestSemantics(t *testing.T) {
 	})
 	if got, want := fmt.Sprint(order), "[before body after]"; got != want {
 		t.Fatalf("ordinary It order = %s, want %s", got, want)
+	}
+}
+
+func TestRunExecutionStopsGeneratedCasesAtFirstFailure(t *testing.T) {
+	gen := newPathGenerator([]PathVar{{Name: "value", Values: []any{1, 2, 3}}}, nil, 0, 0, false, 0, 0, 0)
+	var seen []int
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(ctx *Context) {
+			value := ctx.Path().Int("value")
+			seen = append(seen, value)
+			if value == 2 {
+				ctx.Expect(false).ToEqual(true)
+			}
+		}}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	backend := &controlledBackend{}
+	result := runExecution(backend, nil, plan, 0)
+	if got, want := fmt.Sprint(seen), "[1 2]"; got != want {
+		t.Fatalf("executed generated values = %s, want %s", got, want)
+	}
+	if result.Terminal != proposalTerminalFirstFailure || result.Attempts != 2 || result.Accepted != 2 {
+		t.Fatalf("terminal result = %+v, want first failure after two accepted attempts", result)
+	}
+}
+
+func TestRunExecutionUsesExplicitBoundedControllerConfig(t *testing.T) {
+	gen := newPathGenerator([]PathVar{{Name: "value", Values: []any{1, 2, 3}}}, nil, 0, 0, false, 0, 0, 0)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) {}}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	result := runExecution(&controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalAttemptsBudget || result.Attempts != 3 || result.Accepted != 3 || result.Rejections != 0 {
+		t.Fatalf("terminal result = %+v, want explicit bounded execution of all generated paths", result)
+	}
+}
+
+func TestRunExecutionHonorsCanceledAndDeadlineContexts(t *testing.T) {
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { t.Fatal("body must not run") }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{newPathGenerator([]PathVar{{Name: "value", Values: []any{1}}}, nil, 0, 0, false, 0, 0, 0)},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0); result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("canceled result = %+v, want canceled terminal", result)
+	}
+	deadline, deadlineCancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer deadlineCancel()
+	if result := runExecutionContext(deadline, &controlledBackend{}, nil, plan, 0); result.Terminal != proposalTerminalDeadline {
+		t.Fatalf("deadline result = %+v, want deadline terminal", result)
+	}
+}
+
+func TestDescribePathsDispatchHonorsCancellationAndDeadline(t *testing.T) {
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	deadline, deadlineCancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer deadlineCancel()
+
+	for _, tc := range []struct {
+		name     string
+		ctx      context.Context
+		terminal proposalTerminal
+	}{
+		{name: "canceled", ctx: canceled, terminal: proposalTerminalCanceled},
+		{name: "deadline", ctx: deadline, terminal: proposalTerminalDeadline},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bodyRan := false
+			results := describeWithCompilerContext(t, tc.ctx, "Paths", nil, func(s *Spec) {
+				s.Paths(func(pb *PathBuilder) { pb.Int("value", []int{1}) }).It("case", func(*Context) {
+					bodyRan = true
+				})
+			}, false)
+			if bodyRan || len(results) != 1 || results[0].Terminal != tc.terminal {
+				t.Fatalf("body ran = %t, results = %+v, want terminal %d", bodyRan, results, tc.terminal)
+			}
+		})
+	}
+}
+
+func TestGeneratedFatalUsesRealSubtestBoundary(t *testing.T) {
+	if os.Getenv("GO_SPECS_FATAL_BOUNDARY_HELPER") == "1" {
+		var afterRuns int
+		Describe(t, "fatal boundary", func(s *Spec) {
+			s.AfterEach(func(*Context) { afterRuns++ })
+			s.Paths(func(pb *PathBuilder) { pb.Int("value", []int{1, 2}) }).It("case", func(ctx *Context) {
+				if ctx.Path().Int("value") == 1 {
+					ctx.T.Fatal("generated fatal")
+				}
+				t.Log("second generated case ran")
+			})
+		})
+		t.Logf("controller returned after=%d", afterRuns)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestGeneratedFatalUsesRealSubtestBoundary$")
+	cmd.Env = append(os.Environ(), "GO_SPECS_FATAL_BOUNDARY_HELPER=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("fatal generated case unexpectedly passed: %s", output)
+	}
+	if !strings.Contains(string(output), "controller returned after=1") || strings.Contains(string(output), "second generated case ran") {
+		t.Fatalf("subtest isolation output = %s", output)
 	}
 }

--- a/specs/exploration_controller.go
+++ b/specs/exploration_controller.go
@@ -23,6 +23,14 @@ type proposalCandidate struct {
 	Accepted      bool
 }
 
+// proposalFeedback carries an executed candidate's outcome to AdmitFeedback. It is delivered for
+// both passing and failing candidates, since a failure is feedback too (e.g. for corpus/coverage
+// strategies that want to learn from it).
+type proposalFeedback struct {
+	Candidate proposalCandidate
+	Passed    bool
+}
+
 // proposalControllerResult is the ordered, internal result of a bounded run.
 type proposalControllerResult struct {
 	Seed         int64
@@ -45,7 +53,7 @@ type proposalControllerConfig struct {
 	Propose       func() (PathValues, bool)
 	Accept        func(PathValues) bool
 	Execute       func(proposalCandidate) bool
-	AdmitFeedback func(proposalCandidate)
+	AdmitFeedback func(proposalFeedback)
 }
 
 type proposalController struct{ config proposalControllerConfig }
@@ -97,14 +105,14 @@ func (c proposalController) Run(ctx context.Context) proposalControllerResult {
 		candidate.AcceptedIndex = result.Accepted
 		result.Candidates = append(result.Candidates, candidate)
 		passed := c.config.Execute == nil || c.config.Execute(candidate)
+		if c.config.AdmitFeedback != nil {
+			c.config.AdmitFeedback(proposalFeedback{Candidate: candidate, Passed: passed})
+		}
 		if !passed {
 			result.Terminal = proposalTerminalFirstFailure
 			result.FirstFailure = candidate
 			result.HasFailure = true
 			return result
-		}
-		if c.config.AdmitFeedback != nil {
-			c.config.AdmitFeedback(candidate)
 		}
 		result.Feedback = append(result.Feedback, candidate)
 	}

--- a/specs/exploration_controller_test.go
+++ b/specs/exploration_controller_test.go
@@ -79,7 +79,7 @@ func TestProposalControllerDeterministicOrderingAndSequentialExecution(t *testin
 			},
 			Accept:        func(PathValues) bool { return true },
 			Execute:       func(candidate proposalCandidate) bool { return candidate.Values.Int("value") != 5 },
-			AdmitFeedback: func(candidate proposalCandidate) { feedback = append(feedback, candidate.Values.Int("value")) },
+			AdmitFeedback: func(fb proposalFeedback) { feedback = append(feedback, fb.Candidate.Values.Int("value")) },
 		}).Run(context.Background())
 	}
 
@@ -92,6 +92,40 @@ func TestProposalControllerDeterministicOrderingAndSequentialExecution(t *testin
 	}
 	if first.FirstFailure.AcceptedIndex != 2 || !reflect.DeepEqual(candidateValues(first.Feedback), []int{3}) {
 		t.Fatalf("first failure/feedback=%+v/%v, want accepted index 2 and [3]", first.FirstFailure, candidateValues(first.Feedback))
+	}
+}
+
+// TestProposalControllerAdmitFeedbackFiresForFailureToo would fail against the old contract, where
+// AdmitFeedback was only invoked after a successful Execute and a failing candidate's outcome was
+// silently dropped on the way to the first-failure terminal.
+func TestProposalControllerAdmitFeedbackFiresForFailureToo(t *testing.T) {
+	candidates := []PathValues{pathValue(1), pathValue(2)}
+	var got []proposalFeedback
+	result := newProposalController(proposalControllerConfig{
+		MaxAttempts: 2,
+		Propose: func() (PathValues, bool) {
+			candidate := candidates[0]
+			candidates = candidates[1:]
+			return candidate, true
+		},
+		Accept:  func(PathValues) bool { return true },
+		Execute: func(candidate proposalCandidate) bool { return candidate.Values.Int("value") != 2 },
+		AdmitFeedback: func(fb proposalFeedback) {
+			got = append(got, fb)
+		},
+	}).Run(context.Background())
+
+	if result.Terminal != proposalTerminalFirstFailure {
+		t.Fatalf("terminal=%v, want first failure", result.Terminal)
+	}
+	if len(got) != 2 {
+		t.Fatalf("AdmitFeedback calls=%d, want 2 (fired for both the pass and the failure)", len(got))
+	}
+	if !got[0].Passed || got[0].Candidate.Values.Int("value") != 1 {
+		t.Fatalf("first feedback=%+v, want passed=true value=1", got[0])
+	}
+	if got[1].Passed || got[1].Candidate.Values.Int("value") != 2 {
+		t.Fatalf("second feedback=%+v, want passed=false value=2", got[1])
 	}
 }
 

--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -225,9 +225,10 @@ func newPathGenerator(vars []PathVar, filters []PathFilter, samples int, seed in
 // PathIterator walks the Cartesian product using a single mutable index (odometer style).
 // Use Iterator() for CartesianMode to avoid per-path allocations; Index() is the current position.
 type PathIterator struct {
-	dims  []int
-	index []int
-	done  bool
+	dims    []int
+	index   []int
+	started bool
+	done    bool
 }
 
 // Iterator returns a zero-allocation Cartesian iterator for CartesianMode with no filters, or nil otherwise.
@@ -247,9 +248,21 @@ func (g *PathGenerator) Iterator() *PathIterator {
 }
 
 // Next advances to the next combination (odometer style). Returns false when all combinations have been visited.
+// The first call yields the zero index (the first combination) without advancing it; every
+// call after that advances the odometer before reporting whether a combination remains.
 func (it *PathIterator) Next() bool {
 	if it == nil || it.done {
 		return false
+	}
+	if !it.started {
+		it.started = true
+		for _, d := range it.dims {
+			if d == 0 {
+				it.done = true
+				return false
+			}
+		}
+		return true
 	}
 	for i := len(it.index) - 1; i >= 0; i-- {
 		it.index[i]++
@@ -284,6 +297,137 @@ func (g *PathGenerator) FillPathValues(index []int, pv *PathValues) {
 		pv.present[dim.idx] = true
 		pv.values[dim.idx] = dim.valueAt(index[dimIdx])
 	}
+}
+
+// pathSequence drives a PathGenerator one candidate at a time, replacing the ForEach-into-slice
+// materialization that runExecutionContext used to do before the bounded controller ever saw a
+// candidate. next() must do generation work only — it never depends on, or is influenced by, the
+// result of executing a previously proposed candidate. admitFeedback reports that result back to
+// the generator afterward, so guided strategies can update corpus/novelty state only once the
+// real case has actually run.
+//
+// Only CartesianMode is supported so far; Sample and Explore/ExploreCoverage/ExploreSmart still
+// go through ForEach until a later change extends sequence()/bounds() to those strategies.
+type pathSequence struct {
+	g       *PathGenerator
+	done    bool
+	trivial bool // no vars, or every var collapsed to zero dims: yields exactly one empty PathValues
+
+	it *PathIterator // Cartesian, no filters
+
+	indexes []int // Cartesian with filters: odometer state, mirrors enumerate()
+	started bool
+}
+
+// sequence returns a pathSequence for g. Panics if g uses a mode sequence() doesn't support yet.
+func (g *PathGenerator) sequence() *pathSequence {
+	seq := &pathSequence{g: g}
+	if g == nil || len(g.vars) == 0 || len(g.index) == 0 {
+		seq.trivial = true
+		return seq
+	}
+	if g.mode != CartesianMode {
+		panic("specs: PathGenerator.sequence supports CartesianMode only; Sample/Explore land in a later change")
+	}
+	if len(g.filters) == 0 {
+		seq.it = g.Iterator()
+		return seq
+	}
+	seq.indexes = make([]int, len(g.dims))
+	return seq
+}
+
+// next proposes the next candidate, or (PathValues{}, false) once the space is exhausted.
+func (s *pathSequence) next() (PathValues, bool) {
+	if s == nil || s.done {
+		return PathValues{}, false
+	}
+	if s.trivial {
+		s.done = true
+		return PathValues{}, true
+	}
+	if s.it != nil {
+		if !s.it.Next() {
+			s.done = true
+			return PathValues{}, false
+		}
+		var pv PathValues
+		s.g.FillPathValues(s.it.Index(), &pv)
+		return pv, true
+	}
+	return s.nextFiltered()
+}
+
+// nextFiltered mirrors enumerate()'s odometer, yielding one allowed combination per call instead
+// of visiting the whole space up front.
+func (s *pathSequence) nextFiltered() (PathValues, bool) {
+	g := s.g
+	if len(g.dims) == 0 {
+		if s.started {
+			s.done = true
+			return PathValues{}, false
+		}
+		s.started = true
+		var pv PathValues
+		pv.reset(g.index)
+		if !g.allow(pv) {
+			s.done = true
+			return PathValues{}, false
+		}
+		return pv, true
+	}
+	for {
+		if s.started {
+			if !s.advance() {
+				s.done = true
+				return PathValues{}, false
+			}
+		}
+		s.started = true
+		var pv PathValues
+		pv.reset(g.index)
+		for dimIdx, dim := range g.dims {
+			pv.present[dim.idx] = true
+			pv.values[dim.idx] = dim.valueAt(s.indexes[dimIdx])
+		}
+		if g.allow(pv) {
+			return pv, true
+		}
+	}
+}
+
+func (s *pathSequence) advance() bool {
+	for carry := len(s.indexes) - 1; carry >= 0; carry-- {
+		s.indexes[carry]++
+		if s.indexes[carry] < s.g.dims[carry].len() {
+			return true
+		}
+		s.indexes[carry] = 0
+	}
+	return false
+}
+
+// admitFeedback reports the real outcome of executing candidate back to the generator. It is a
+// no-op for Cartesian (and, once implemented, Sample): neither strategy has feedback-dependent
+// state. Explore/ExploreCoverage/ExploreSmart will use it to move corpus/seen-state growth to
+// after the real case runs, once those strategies gain sequence() support.
+func (s *pathSequence) admitFeedback(candidate PathValues, passed bool) {}
+
+// bounds returns conservative (never-underestimating) MaxAttempts/MaxAccepted/MaxRejections
+// upper bounds for proposalControllerConfig, computed without generating a single candidate.
+// Panics if g uses a mode sequence()/bounds() doesn't support yet.
+func (g *PathGenerator) bounds() (maxAttempts, maxAccepted, maxRejections int) {
+	if g == nil || len(g.vars) == 0 || len(g.index) == 0 {
+		return 1, 1, 1
+	}
+	if g.mode != CartesianMode {
+		panic("specs: PathGenerator.bounds supports CartesianMode only; Sample/Explore land in a later change")
+	}
+	total := 1
+	for _, dim := range g.dims {
+		total *= dim.len()
+	}
+	return total, total, total
 }
 
 // ForEach iterates over every allowed combination in declaration order.
@@ -406,13 +550,16 @@ func (g *PathGenerator) runExploration(fn func(PathValues)) {
 //
 // Real coverage-guided corpus growth needs ctx.coverage populated with genuine assertion-level
 // edge data on every iteration, which requires wiring the runner to set it per path iteration —
-// not yet done (tracked separately; PathGenerator.ForEach itself isn't invoked by the top-level
-// Describe execution path today either, a larger pre-existing gap — see the 8 tests skipped
-// "paths combinatorial execution with top-level Describe deferred to post-v1.0.0" in
-// paths_test.go). Until real coverage feedback exists, corpus growth uses the same call-site-
-// signature novelty heuristic the plain strategy already uses (captureSignature) as an honest,
-// documented proxy — good enough to give NextInput something to mutate from instead of always
-// falling back to fully random input, but not genuine coverage-guided selection.
+// not yet done. Cartesian dispatch from the top-level Describe execution path is incremental
+// (runExecutionContext drives it through PathGenerator.sequence(), one candidate at a time, only
+// admitting feedback after the real case has run); Sampling and ExplorationGuided — this method
+// included — still go through this ForEach-driven path, fully generated before the runner
+// executes a single case, so corpus growth here still can't depend on a real per-iteration
+// result. Until sequence()/admitFeedback() cover these strategies too, corpus growth uses the
+// same call-site-signature novelty heuristic the plain strategy already uses (captureSignature)
+// as an honest, documented proxy — good enough to give NextInput something to mutate from
+// instead of always falling back to fully random input, but not genuine coverage-guided
+// selection.
 func (g *PathGenerator) runGuidedExploration(fn func(PathValues), nextInput func(*PathGenerator) PathValues, corpus *Corpus) {
 	executed := 0
 	for executed < g.iterations {

--- a/specs/path_generator_test.go
+++ b/specs/path_generator_test.go
@@ -1,0 +1,124 @@
+package specs
+
+import (
+	"reflect"
+	"testing"
+)
+
+// collectSequence drains a pathSequence, formatting each candidate the same way ForEach's
+// caller would (via FormatPathValuesForReport) so it can be compared against ForEach's output.
+func collectSequence(g *PathGenerator) []string {
+	seq := g.sequence()
+	var got []string
+	for {
+		pv, ok := seq.next()
+		if !ok {
+			break
+		}
+		got = append(got, g.FormatPathValuesForReport(pv))
+	}
+	return got
+}
+
+func collectForEach(g *PathGenerator) []string {
+	var want []string
+	g.ForEach(func(pv PathValues) { want = append(want, g.FormatPathValuesForReport(pv)) })
+	return want
+}
+
+func TestPathSequenceCartesianMatchesForEachOrder(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", Values: []any{1, 2, 3}},
+		{Name: "y", Values: []any{"a", "b"}},
+	}, nil, 0, 0, false, 0, 0, 0)
+
+	got, want := collectSequence(gen), collectForEach(gen)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sequence order = %v, want %v (must match ForEach exactly, including the first combination)", got, want)
+	}
+	if len(got) != 6 {
+		t.Fatalf("len(got) = %d, want 6 (3x2 combinations)", len(got))
+	}
+}
+
+func TestPathSequenceCartesianWithFiltersMatchesForEachOrder(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", Values: []any{1, 2, 3, 4}},
+	}, []PathFilter{func(pv PathValues) bool {
+		v, _ := pv.lookup("x")
+		return v.(int)%2 == 0
+	}}, 0, 0, false, 0, 0, 0)
+
+	got, want := collectSequence(gen), collectForEach(gen)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filtered sequence order = %v, want %v", got, want)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2 (only even x)", len(got))
+	}
+}
+
+func TestPathSequenceTrivialGeneratorYieldsOneEmptyValue(t *testing.T) {
+	gen := newPathGenerator(nil, nil, 0, 0, false, 0, 0, 0)
+	seq := gen.sequence()
+	if _, ok := seq.next(); !ok {
+		t.Fatal("expected exactly one candidate for a generator with no vars")
+	}
+	if _, ok := seq.next(); ok {
+		t.Fatal("expected exhaustion after the single trivial candidate")
+	}
+}
+
+func TestPathSequenceAdmitFeedbackIsNoOpForCartesian(t *testing.T) {
+	gen := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2}}}, nil, 0, 0, false, 0, 0, 0)
+	seq := gen.sequence()
+	before, _ := seq.next()
+	seq.admitFeedback(before, true)
+	seq.admitFeedback(before, false)
+	after, ok := seq.next()
+	if !ok {
+		t.Fatal("expected a second candidate")
+	}
+	if reflect.DeepEqual(before, after) {
+		t.Fatal("second candidate must differ from the first regardless of admitFeedback calls")
+	}
+}
+
+func TestPathGeneratorBoundsIsConservativeUpperBound(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", Values: []any{1, 2, 3}},
+		{Name: "y", Values: []any{"a", "b"}},
+	}, []PathFilter{func(pv PathValues) bool {
+		v, _ := pv.lookup("x")
+		return v.(int) == 1
+	}}, 0, 0, false, 0, 0, 0)
+
+	maxAttempts, maxAccepted, maxRejections := gen.bounds()
+	if maxAttempts != 6 || maxAccepted != 6 || maxRejections != 6 {
+		t.Fatalf("bounds = (%d, %d, %d), want (6, 6, 6) — the raw product, ignoring filters", maxAttempts, maxAccepted, maxRejections)
+	}
+	actual := len(collectSequence(gen))
+	if actual >= maxAccepted {
+		t.Fatalf("actual accepted candidates = %d, want fewer than the conservative bound %d (filters reduce the real count)", actual, maxAccepted)
+	}
+}
+
+func TestPathSequencePanicsForUnsupportedModes(t *testing.T) {
+	sample := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2, 3}}}, nil, 2, 0, false, 0, 0, 0)
+	assertPanics(t, func() { sample.sequence() })
+	assertPanics(t, func() { sample.bounds() })
+
+	explore := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2, 3}}}, nil, 0, 0, false, 5, 0, 0)
+	assertPanics(t, func() { explore.sequence() })
+	assertPanics(t, func() { explore.bounds() })
+}
+
+func assertPanics(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected a panic")
+		}
+	}()
+	fn()
+}

--- a/specs/paths_test.go
+++ b/specs/paths_test.go
@@ -57,7 +57,6 @@ func TestPathsAnalyzeKeepsSingleNode(t *testing.T) {
 }
 
 func TestPathsExecutesAllCombinations(t *testing.T) {
-	t.Skip("paths combinatorial execution with top-level Describe deferred to post-v1.0.0")
 	var hits []string
 	var mu sync.Mutex
 	Describe(t, "Paths", func(s *Spec) {
@@ -88,8 +87,21 @@ func TestPathsExecutesAllCombinations(t *testing.T) {
 	}
 }
 
+func TestPathsExecutesGeneratedCasesSequentiallyInDeclarationOrder(t *testing.T) {
+	var order []int
+	Describe(t, "PathsSequential", func(s *Spec) {
+		s.Paths(func(pb *PathBuilder) {
+			pb.Int("value", []int{1, 2, 3})
+		}).It("case", func(ctx *Context) {
+			order = append(order, ctx.Path().Int("value"))
+		})
+	})
+	if got, want := fmt.Sprint(order), "[1 2 3]"; got != want {
+		t.Fatalf("generated execution order = %s, want %s", got, want)
+	}
+}
+
 func TestPathsFiltersCombinations(t *testing.T) {
-	t.Skip("paths combinatorial execution with top-level Describe deferred to post-v1.0.0")
 	var hits []string
 	var mu sync.Mutex
 	Describe(t, "PathsFilter", func(s *Spec) {
@@ -125,8 +137,27 @@ func TestPathsFiltersCombinations(t *testing.T) {
 	}
 }
 
+func TestPathsCasesUseIsolatedHooksAndContext(t *testing.T) {
+	var order []string
+	Describe(t, "PathLifecycle", func(s *Spec) {
+		s.BeforeEach(func(ctx *Context) {
+			if ctx.Path().Int("value") == 0 {
+				t.Fatal("missing generated path value")
+			}
+			order = append(order, "before")
+		})
+		s.AfterEach(func(*Context) { order = append(order, "after") })
+		s.Paths(func(pb *PathBuilder) { pb.Int("value", []int{1, 2}) }).It("case", func(ctx *Context) {
+			order = append(order, fmt.Sprintf("body-%d", ctx.Path().Int("value")))
+		})
+	})
+	if got, want := fmt.Sprint(order), "[before body-1 after before body-2 after]"; got != want {
+		t.Fatalf("case lifecycle = %s, want %s", got, want)
+	}
+}
+
 func TestPathsReporterIncludesCombinationNames(t *testing.T) {
-	t.Skip("paths combinatorial execution with top-level Describe deferred to post-v1.0.0")
+	t.Skip("generated reporting is deferred until the later reporting gate")
 	var buf bytes.Buffer
 	reporter := report.New(&buf)
 	DescribeWithReporter(t, "Paths", reporter, func(s *Spec) {
@@ -148,7 +179,6 @@ func TestPathsReporterIncludesCombinationNames(t *testing.T) {
 }
 
 func TestPathsSampleExecutesRequestedCount(t *testing.T) {
-	t.Skip("paths combinatorial execution with top-level Describe deferred to post-v1.0.0")
 	const samples = 5
 	var mu sync.Mutex
 	var prices []int
@@ -203,7 +233,6 @@ func TestPathsSampleDeterministicWithSeed(t *testing.T) {
 }
 
 func TestPathsSampleRespectsFilters(t *testing.T) {
-	t.Skip("paths combinatorial execution with top-level Describe deferred to post-v1.0.0")
 	var mu sync.Mutex
 	var hits []int
 	Describe(t, "PathsSampleFilters", func(s *Spec) {
@@ -229,7 +258,7 @@ func TestPathsSampleRespectsFilters(t *testing.T) {
 }
 
 func TestPathsSampleReporterNamesIncludeSample(t *testing.T) {
-	t.Skip("paths combinatorial execution with top-level Describe deferred to post-v1.0.0")
+	t.Skip("generated reporting is deferred until the later reporting gate")
 	var buf bytes.Buffer
 	reporter := report.New(&buf)
 	DescribeWithReporter(t, "PathsSampleReporter", reporter, func(s *Spec) {
@@ -245,7 +274,6 @@ func TestPathsSampleReporterNamesIncludeSample(t *testing.T) {
 }
 
 func TestPathsExploreRunsExpectedIterations(t *testing.T) {
-	t.Skip("paths combinatorial execution with top-level Describe deferred to post-v1.0.0")
 	const iterations = 10
 	var mu sync.Mutex
 	var count int
@@ -294,7 +322,6 @@ func TestPathsExploreDeterministicWithSeed(t *testing.T) {
 }
 
 func TestPathsExploreRespectsFilters(t *testing.T) {
-	t.Skip("paths combinatorial execution with top-level Describe deferred to post-v1.0.0")
 	var mu sync.Mutex
 	var values []int
 	Describe(t, "PathsExploreFilters", func(s *Spec) {
@@ -448,7 +475,8 @@ func TestExploreCoverageRuns(t *testing.T) {
 			p.IntRange("x", 0, 100)
 			p.IntRange("y", 0, 100)
 		}).ExploreCoverage(20).It("property", func(ctx *Context) {
-			ctx.Expect(ctx.Path().Int("x") + ctx.Path().Int("y")).ToEqual(ctx.Path().Int("x") + ctx.Path().Int("y"))
+			x, y := ctx.Path().Int("x"), ctx.Path().Int("y")
+			ctx.Expect(x+y >= x && x+y >= y).ToEqual(true)
 		})
 	})
 }
@@ -459,7 +487,8 @@ func TestExploreSmartRuns(t *testing.T) {
 			p.IntRange("x", 0, 100)
 			p.IntRange("y", 0, 100)
 		}).ExploreSmart(25).It("property", func(ctx *Context) {
-			ctx.Expect(ctx.Path().Int("x") + ctx.Path().Int("y")).ToEqual(ctx.Path().Int("x") + ctx.Path().Int("y"))
+			x, y := ctx.Path().Int("x"), ctx.Path().Int("y")
+			ctx.Expect(x+y >= x && x+y >= y).ToEqual(true)
 		})
 	})
 }

--- a/specs/spec.go
+++ b/specs/spec.go
@@ -1,6 +1,7 @@
 package specs
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -17,12 +18,12 @@ type Spec struct {
 	hasSeed  bool
 
 	// Either (arena, rootID) when built via Analyze/registry, or plan when built via bytecode compiler.
-	arena   *NodeArena
-	rootID  int
-	plan    *ExecutionPlan // set by top-level Describe when using bytecode compiler (no arena)
-	flat    bool          // if true, run all specs in one test (no subtests)
+	arena       *NodeArena
+	rootID      int
+	plan        *ExecutionPlan // set by top-level Describe when using bytecode compiler (no arena)
+	flat        bool           // if true, run all specs in one test (no subtests)
 	compileOnce sync.Once
-	suite   *CompiledSuite
+	suite       *CompiledSuite
 }
 
 // Describe starts a top-level describe block. May be called inside Analyze(fn) or directly.
@@ -57,6 +58,10 @@ func Describe(tb testing.TB, name string, fn func(*Spec)) {
 
 // describeWithCompiler runs Describe using the bytecode compiler (no arena).
 func describeWithCompiler(tb testing.TB, name string, rep report.EventReporter, fn func(*Spec), flat bool) {
+	describeWithCompilerContext(tb, nil, name, rep, fn, flat)
+}
+
+func describeWithCompilerContext(tb testing.TB, runCtx context.Context, name string, rep report.EventReporter, fn func(*Spec), flat bool) []proposalControllerResult {
 	c := newBytecodeCompiler()
 	c.PushScope(name)
 	pushCompiler(c)
@@ -75,8 +80,9 @@ func describeWithCompiler(tb testing.TB, name string, rep report.EventReporter, 
 	s.plan = c.TakePlan()
 	if tb != nil {
 		s.Compile()
-		s.Run()
+		return s.suite.run(tb, runCtx)
 	}
+	return nil
 }
 
 // BuildSuite builds the spec tree and compiles it once; returns the CompiledSuite without running.


### PR DESCRIPTION
Part of #43

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Connects the PR2A controller foundation to real sequential `Describe → Paths → It` generated-path dispatch.
- Preserves context/deadline terminal behavior and isolates each generated lifecycle so `Fatal` and `FailNow` stop only the active case.

## Changes

| File | Change |
|------|--------|
| `specs/execution_plan.go` | Routes generated path values through the bounded controller, execution context, and isolated case boundary. |
| `specs/execution_plan_test.go` | Verifies first-failure, context/deadline terminals, and real subtest isolation. |
| `specs/paths_test.go` | Enables generated path execution coverage for combinations, sampling, exploration, order, filters, and lifecycle semantics. |
| `specs/spec.go` | Passes an optional compiler execution context into compiled-suite dispatch. |

## Chain Context

- Strategy: Feature Branch Chain
- Start: tracker `feat/automatic-spec-exploration`
- Current boundary: real sequential generated `Paths` dispatch, context/deadline terminals, and isolated lifecycle semantics (238 additions; 25 deletions).
- Dependency: `feat/automatic-spec-exploration-pr2a` provides the bounded proposal controller foundation.
- Out of scope: generated reporting and later exploration feedback/shrinking work.

```text
feat/automatic-spec-exploration (tracker)
  └── feat/automatic-spec-exploration-pr2a (controller foundation)
        └── 📍 feat/automatic-spec-exploration-pr2b (this PR)
```

## Test Plan

- [x] `make test`
- [x] `make test-race`
- [x] No shell scripts were modified; shellcheck is not applicable.

## Contributor Checklist

- [x] References approved issue `#43` without resolving it.
- [x] Added exactly one `type:*` label (`type:feature`).
- [x] Shellcheck is not applicable because no shell scripts were modified.
- [x] Required delivery skills were loaded in the delivery agent.
- [x] Documentation is not required because the stable public DSL is unchanged.
- [x] Uses a Conventional Commit title and commit (`feat(specs): dispatch generated paths through controller`).
- [x] Contains no `Co-Authored-By` trailers.