### PR TITLE
feat(specs): dispatch SamplingMode paths incrementally via pathSequence

### DIFF
--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -202,7 +202,7 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 		return proposalControllerResult{}
 	}
 	program := plan.Instructions[start : start+length]
-	if i < len(plan.PathGens) && plan.PathGens[i] != nil && plan.PathGens[i].mode == CartesianMode {
+	if i < len(plan.PathGens) && plan.PathGens[i] != nil && (plan.PathGens[i].mode == CartesianMode || plan.PathGens[i].mode == SamplingMode) {
 		gen := plan.PathGens[i]
 		seq := gen.sequence()
 		maxAttempts, maxAccepted, maxRejections := gen.bounds()
@@ -220,8 +220,8 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 		}).Run(runCtx)
 	}
 	if i < len(plan.PathGens) && plan.PathGens[i] != nil {
-		// Sample and Explore/ExploreCoverage/ExploreSmart still materialize via ForEach until a
-		// later change extends sequence()/bounds() to those strategies (see path_generator.go).
+		// Explore/ExploreCoverage/ExploreSmart still materialize via ForEach until a later change
+		// extends sequence()/bounds() to those strategies (see path_generator.go).
 		paths := make([]PathValues, 0)
 		plan.PathGens[i].ForEach(func(path PathValues) { paths = append(paths, path.clone()) })
 		next := 0

--- a/specs/execution_plan_test.go
+++ b/specs/execution_plan_test.go
@@ -237,6 +237,52 @@ func TestRunExecutionContextCartesianStopsGeneratingOnCancelMidRun(t *testing.T)
 	}
 }
 
+// TestRunExecutionContextSampleDoesNotMaterializeUnderCancellation is Sample's counterpart to
+// TestRunExecutionContextCartesianDoesNotMaterializeUnderCancellation: proves runExecutionContext
+// no longer routes SamplingMode through the ForEach/[]PathValues fallback, which would have
+// generated every sample (and run every filter) before the controller ever observed cancellation.
+func TestRunExecutionContextSampleDoesNotMaterializeUnderCancellation(t *testing.T) {
+	var considered int
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 999}}},
+		[]PathFilter{func(PathValues) bool { considered++; return true }}, 5, 0, false, 0, 0, 0)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { t.Fatal("body must not run") }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal = %v, want canceled", result.Terminal)
+	}
+	if considered != 0 {
+		t.Fatalf("candidates considered before the controller observed cancellation = %d, want 0", considered)
+	}
+}
+
+// TestRunExecutionContextSampleStopsGeneratingOnCancelMidRun is Sample's counterpart to
+// TestRunExecutionContextCartesianStopsGeneratingOnCancelMidRun.
+func TestRunExecutionContextSampleStopsGeneratingOnCancelMidRun(t *testing.T) {
+	var considered, executed int
+	ctx, cancel := context.WithCancel(context.Background())
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 999}}},
+		[]PathFilter{func(PathValues) bool { considered++; return true }}, 5, 0, false, 0, 0, 0)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { executed++; cancel() }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal = %v, want canceled", result.Terminal)
+	}
+	if executed != 1 {
+		t.Fatalf("executed = %d, want exactly 1 (canceled from inside the first case)", executed)
+	}
+	if considered != 1 {
+		t.Fatalf("candidates considered = %d, want 1 — generation must not run ahead of execution", considered)
+	}
+}
+
 func TestGeneratedFatalUsesRealSubtestBoundary(t *testing.T) {
 	if os.Getenv("GO_SPECS_FATAL_BOUNDARY_HELPER") == "1" {
 		var afterRuns int

--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -620,16 +620,16 @@ func (g *PathGenerator) runExploration(fn func(PathValues)) {
 //
 // Real coverage-guided corpus growth needs ctx.coverage populated with genuine assertion-level
 // edge data on every iteration, which requires wiring the runner to set it per path iteration —
-// not yet done. Cartesian dispatch from the top-level Describe execution path is incremental
-// (runExecutionContext drives it through PathGenerator.sequence(), one candidate at a time, only
-// admitting feedback after the real case has run); Sampling and ExplorationGuided — this method
-// included — still go through this ForEach-driven path, fully generated before the runner
-// executes a single case, so corpus growth here still can't depend on a real per-iteration
-// result. Until sequence()/admitFeedback() cover these strategies too, corpus growth uses the
-// same call-site-signature novelty heuristic the plain strategy already uses (captureSignature)
-// as an honest, documented proxy — good enough to give NextInput something to mutate from
-// instead of always falling back to fully random input, but not genuine coverage-guided
-// selection.
+// not yet done. Cartesian and Sampling dispatch from the top-level Describe execution path are
+// incremental (runExecutionContext drives them through PathGenerator.sequence(), one candidate at
+// a time, only admitting feedback after the real case has run); ExplorationGuided — this method's
+// strategies (Coverage/Smart) included — still goes through this ForEach-driven path, fully
+// generated before the runner executes a single case, so corpus growth here still can't depend on
+// a real per-iteration result. Until sequence()/admitFeedback() cover this mode too, corpus growth
+// uses the same call-site-signature novelty heuristic the plain strategy already uses
+// (captureSignature) as an honest, documented proxy — good enough to give NextInput something to
+// mutate from instead of always falling back to fully random input, but not genuine
+// coverage-guided selection.
 func (g *PathGenerator) runGuidedExploration(fn func(PathValues), nextInput func(*PathGenerator) PathValues, corpus *Corpus) {
 	executed := 0
 	for executed < g.iterations {

--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -306,7 +306,7 @@ func (g *PathGenerator) FillPathValues(index []int, pv *PathValues) {
 // the generator afterward, so guided strategies can update corpus/novelty state only once the
 // real case has actually run.
 //
-// Only CartesianMode is supported so far; Sample and Explore/ExploreCoverage/ExploreSmart still
+// CartesianMode and SamplingMode are supported so far; Explore/ExploreCoverage/ExploreSmart still
 // go through ForEach until a later change extends sequence()/bounds() to those strategies.
 type pathSequence struct {
 	g       *PathGenerator
@@ -317,6 +317,16 @@ type pathSequence struct {
 
 	indexes []int // Cartesian with filters: odometer state, mirrors enumerate()
 	started bool
+
+	// Sample: mirrors runSamples' state one call to next() at a time instead of looping to
+	// completion up front. sampleAttempts/sampleMaxAttempts preserve runSamples' samples*100
+	// retry budget and panic message; the budget and the filter-retry loop are both internal to
+	// nextSample and never surface to the proposalController as separate Propose calls.
+	sampleIdx         int
+	hasSampleVar      bool
+	sampleExecuted    int
+	sampleAttempts    int
+	sampleMaxAttempts int
 }
 
 // sequence returns a pathSequence for g. Panics if g uses a mode sequence() doesn't support yet.
@@ -326,15 +336,27 @@ func (g *PathGenerator) sequence() *pathSequence {
 		seq.trivial = true
 		return seq
 	}
-	if g.mode != CartesianMode {
-		panic("specs: PathGenerator.sequence supports CartesianMode only; Sample/Explore land in a later change")
-	}
-	if len(g.filters) == 0 {
-		seq.it = g.Iterator()
+	switch g.mode {
+	case CartesianMode:
+		if len(g.filters) == 0 {
+			seq.it = g.Iterator()
+			return seq
+		}
+		seq.indexes = make([]int, len(g.dims))
 		return seq
+	case SamplingMode:
+		seq.sampleIdx, seq.hasSampleVar = g.index[sampleVarName]
+		seq.sampleMaxAttempts = g.samples * 100
+		if seq.sampleMaxAttempts < g.samples {
+			seq.sampleMaxAttempts = g.samples
+		}
+		if g.samples <= 0 {
+			seq.done = true
+		}
+		return seq
+	default:
+		panic("specs: PathGenerator.sequence supports CartesianMode/SamplingMode only; Explore lands in a later change")
 	}
-	seq.indexes = make([]int, len(g.dims))
-	return seq
 }
 
 // next proposes the next candidate, or (PathValues{}, false) once the space is exhausted.
@@ -355,7 +377,44 @@ func (s *pathSequence) next() (PathValues, bool) {
 		s.g.FillPathValues(s.it.Index(), &pv)
 		return pv, true
 	}
+	if s.g.mode == SamplingMode {
+		return s.nextSample()
+	}
 	return s.nextFiltered()
+}
+
+// nextSample mirrors runSamples: draw a random value per dimension, retry internally against
+// filters up to the same samples*100 attempt budget (panicking with the same message if that
+// budget is exhausted), and number the synthetic "sample" dimension 1-indexed. Each call yields
+// at most one filter-accepted candidate; the internal retries never surface to the
+// proposalController as separate Propose calls.
+func (s *pathSequence) nextSample() (PathValues, bool) {
+	g := s.g
+	if s.sampleExecuted >= g.samples {
+		s.done = true
+		return PathValues{}, false
+	}
+	for {
+		s.sampleAttempts++
+		if s.sampleAttempts > s.sampleMaxAttempts {
+			panic("specs: sampling could not satisfy filters; reduce sample count or relax filters")
+		}
+		var pv PathValues
+		pv.reset(g.index)
+		for _, dim := range g.dims {
+			pv.present[dim.idx] = true
+			pv.values[dim.idx] = dim.randomValue(g.rng)
+		}
+		if s.hasSampleVar {
+			pv.present[s.sampleIdx] = true
+			pv.values[s.sampleIdx] = s.sampleExecuted + 1
+		}
+		if !g.allow(pv) {
+			continue
+		}
+		s.sampleExecuted++
+		return pv, true
+	}
 }
 
 // nextFiltered mirrors enumerate()'s odometer, yielding one allowed combination per call instead
@@ -408,9 +467,10 @@ func (s *pathSequence) advance() bool {
 }
 
 // admitFeedback reports the real outcome of executing candidate back to the generator. It is a
-// no-op for Cartesian (and, once implemented, Sample): neither strategy has feedback-dependent
-// state. Explore/ExploreCoverage/ExploreSmart will use it to move corpus/seen-state growth to
-// after the real case runs, once those strategies gain sequence() support.
+// no-op for Cartesian and Sample: neither strategy has feedback-dependent state — Sample's
+// candidates are drawn independently of prior results, same as runSamples always was.
+// Explore/ExploreCoverage/ExploreSmart will use it to move corpus/seen-state growth to after the
+// real case runs, once those strategies gain sequence() support.
 func (s *pathSequence) admitFeedback(candidate PathValues, passed bool) {}
 
 // bounds returns conservative (never-underestimating) MaxAttempts/MaxAccepted/MaxRejections
@@ -420,14 +480,24 @@ func (g *PathGenerator) bounds() (maxAttempts, maxAccepted, maxRejections int) {
 	if g == nil || len(g.vars) == 0 || len(g.index) == 0 {
 		return 1, 1, 1
 	}
-	if g.mode != CartesianMode {
-		panic("specs: PathGenerator.bounds supports CartesianMode only; Sample/Explore land in a later change")
+	switch g.mode {
+	case CartesianMode:
+		total := 1
+		for _, dim := range g.dims {
+			total *= dim.len()
+		}
+		return total, total, total
+	case SamplingMode:
+		// next() emits at most g.samples candidates (nextSample's own retry budget is internal
+		// and never surfaces as separate Propose calls), so g.samples is an exact bound, not just
+		// a conservative one.
+		if g.samples <= 0 {
+			return 0, 0, 0
+		}
+		return g.samples, g.samples, g.samples
+	default:
+		panic("specs: PathGenerator.bounds supports CartesianMode/SamplingMode only; Explore lands in a later change")
 	}
-	total := 1
-	for _, dim := range g.dims {
-		total *= dim.len()
-	}
-	return total, total, total
 }
 
 // ForEach iterates over every allowed combination in declaration order.

--- a/specs/path_generator_test.go
+++ b/specs/path_generator_test.go
@@ -104,13 +104,106 @@ func TestPathGeneratorBoundsIsConservativeUpperBound(t *testing.T) {
 }
 
 func TestPathSequencePanicsForUnsupportedModes(t *testing.T) {
-	sample := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2, 3}}}, nil, 2, 0, false, 0, 0, 0)
-	assertPanics(t, func() { sample.sequence() })
-	assertPanics(t, func() { sample.bounds() })
-
 	explore := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2, 3}}}, nil, 0, 0, false, 5, 0, 0)
 	assertPanics(t, func() { explore.sequence() })
 	assertPanics(t, func() { explore.bounds() })
+}
+
+func TestPathSequenceSampleEmitsExactlyRequestedCount(t *testing.T) {
+	const samples = 7
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 100}},
+	}, nil, samples, 0, false, 0, 0, 0)
+
+	got := collectSequence(gen)
+	if len(got) != samples {
+		t.Fatalf("len(got) = %d, want %d", len(got), samples)
+	}
+}
+
+func TestPathSequenceSampleMatchesRunSamplesForSameSeed(t *testing.T) {
+	newGen := func() *PathGenerator {
+		return newPathGenerator([]PathVar{
+			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+		}, nil, 5, 42, true, 0, 0, 0)
+	}
+
+	got := collectSequence(newGen())
+	want := collectForEach(newGen())
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sequence-based samples = %v, want %v (must match runSamples exactly for the same seed)", got, want)
+	}
+}
+
+func TestPathSequenceSampleRespectsFilters(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 20}},
+	}, []PathFilter{func(pv PathValues) bool {
+		v, _ := pv.lookup("x")
+		return v.(int)%2 == 0
+	}}, 6, 0, false, 0, 0, 0)
+
+	seq := gen.sequence()
+	for i := 0; i < 6; i++ {
+		pv, ok := seq.next()
+		if !ok {
+			t.Fatalf("expected candidate %d, got exhaustion", i)
+		}
+		if pv.Int("x")%2 != 0 {
+			t.Fatalf("expected even x, got %d", pv.Int("x"))
+		}
+	}
+	if _, ok := seq.next(); ok {
+		t.Fatal("expected exhaustion after 6 accepted candidates")
+	}
+}
+
+func TestPathSequenceSamplePanicsWhenFiltersCannotBeSatisfied(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", Values: []any{1}},
+	}, []PathFilter{func(PathValues) bool { return false }}, 3, 0, false, 0, 0, 0)
+
+	seq := gen.sequence()
+	assertPanics(t, func() { seq.next() })
+}
+
+func TestPathSequenceSampleBoundsIsExact(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 100}},
+	}, nil, 9, 0, false, 0, 0, 0)
+
+	maxAttempts, maxAccepted, maxRejections := gen.bounds()
+	if maxAttempts != 9 || maxAccepted != 9 || maxRejections != 9 {
+		t.Fatalf("bounds = (%d, %d, %d), want (9, 9, 9)", maxAttempts, maxAccepted, maxRejections)
+	}
+	if got := len(collectSequence(gen)); got != maxAccepted {
+		t.Fatalf("actual accepted candidates = %d, want exactly %d", got, maxAccepted)
+	}
+}
+
+func TestPathSequenceSampleAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
+	newGen := func() *PathGenerator {
+		return newPathGenerator([]PathVar{
+			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+		}, nil, 5, 7, true, 0, 0, 0)
+	}
+
+	baseline := collectSequence(newGen())
+
+	gen := newGen()
+	seq := gen.sequence()
+	var withFeedback []string
+	for {
+		pv, ok := seq.next()
+		if !ok {
+			break
+		}
+		withFeedback = append(withFeedback, gen.FormatPathValuesForReport(pv))
+		seq.admitFeedback(pv, withFeedback != nil)
+	}
+	if !reflect.DeepEqual(baseline, withFeedback) {
+		t.Fatalf("admitFeedback altered the sequence: got %v, want %v", withFeedback, baseline)
+	}
 }
 
 func assertPanics(t *testing.T, fn func()) {


### PR DESCRIPTION
## Summary
Part of #43 (PR1 of 4). Extends the incremental execution path introduced for `CartesianMode` in #48/#49 to `SamplingMode`, so `runExecutionContext` no longer materializes every sample into a `[]PathValues` before the controller runs the first case.

- `PathGenerator.sequence()`/`bounds()` now support `SamplingMode` (previously panicked).
- `pathSequence.nextSample()` mirrors `runSamples()`'s exact semantics one candidate at a time: random draw per dimension, internal filter retry with the same `samples*100` attempt budget, same panic message on exhaustion, 1-indexed `sample` var.
- `bounds()` for Sample returns `(g.samples, g.samples, g.samples)` — exact, since `next()` never emits more than requested.
- `admitFeedback` stays a no-op for Sample (candidates don't depend on prior execution results).
- `runExecutionContext` now routes `CartesianMode || SamplingMode` through the incremental path; Explore/ExploreCoverage/ExploreSmart are untouched, still on the `ForEach` batch fallback.

## Scope
Sample only. Explore/ExploreCoverage/ExploreSmart come in PR2/PR3; removing the fallback entirely is PR4.

## Test plan
- [x] New: `TestPathSequenceSampleEmitsExactlyRequestedCount`, `TestPathSequenceSampleMatchesRunSamplesForSameSeed`, `TestPathSequenceSampleRespectsFilters`, `TestPathSequenceSamplePanicsWhenFiltersCannotBeSatisfied`, `TestPathSequenceSampleBoundsIsExact`, `TestPathSequenceSampleAdmitFeedbackDoesNotAlterSequence`
- [x] New (non-materialization evidence, mirrors the existing Cartesian tests): `TestRunExecutionContextSampleDoesNotMaterializeUnderCancellation`, `TestRunExecutionContextSampleStopsGeneratingOnCancelMidRun`
- [x] Existing `TestPathsSampleExecutesRequestedCount`/`TestPathsSampleDeterministicWithSeed`/`TestPathsSampleRespectsFilters` pass unchanged
- [x] `gofmt -l`, `go vet ./...`, `go test ./...`, `go test ./... -race` all clean