### PR TITLE
feat(specs): migrate plain Explore to the incremental execution path

### DIFF
--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -202,7 +202,11 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 		return proposalControllerResult{}
 	}
 	program := plan.Instructions[start : start+length]
-	if i < len(plan.PathGens) && plan.PathGens[i] != nil && (plan.PathGens[i].mode == CartesianMode || plan.PathGens[i].mode == SamplingMode) {
+	incrementalCapable := i < len(plan.PathGens) && plan.PathGens[i] != nil &&
+		(plan.PathGens[i].mode == CartesianMode ||
+			plan.PathGens[i].mode == SamplingMode ||
+			(plan.PathGens[i].mode == ExplorationGuided && plan.PathGens[i].strategy == strategyPlain))
+	if incrementalCapable {
 		gen := plan.PathGens[i]
 		seq := gen.sequence()
 		maxAttempts, maxAccepted, maxRejections := gen.bounds()
@@ -220,8 +224,8 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 		}).Run(runCtx)
 	}
 	if i < len(plan.PathGens) && plan.PathGens[i] != nil {
-		// Explore/ExploreCoverage/ExploreSmart still materialize via ForEach until a later change
-		// extends sequence()/bounds() to those strategies (see path_generator.go).
+		// ExploreCoverage/ExploreSmart still materialize via ForEach until a later change extends
+		// sequence()/bounds() to those two guided strategies (see path_generator.go).
 		paths := make([]PathValues, 0)
 		plan.PathGens[i].ForEach(func(path PathValues) { paths = append(paths, path.clone()) })
 		next := 0

--- a/specs/execution_plan_test.go
+++ b/specs/execution_plan_test.go
@@ -283,6 +283,55 @@ func TestRunExecutionContextSampleStopsGeneratingOnCancelMidRun(t *testing.T) {
 	}
 }
 
+// TestRunExecutionContextExploreDoesNotMaterializeUnderCancellation is plain Explore's counterpart
+// to TestRunExecutionContextCartesianDoesNotMaterializeUnderCancellation: proves runExecutionContext
+// no longer routes strategyPlain ExplorationGuided through the ForEach/[]PathValues fallback, which
+// would have generated every iteration (and run every filter) before the controller ever observed
+// cancellation.
+func TestRunExecutionContextExploreDoesNotMaterializeUnderCancellation(t *testing.T) {
+	var considered int
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 999}}},
+		[]PathFilter{func(PathValues) bool { considered++; return true }}, 0, 0, false, 5, 0, 0)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { t.Fatal("body must not run") }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal = %v, want canceled", result.Terminal)
+	}
+	if considered != 0 {
+		t.Fatalf("candidates considered before the controller observed cancellation = %d, want 0", considered)
+	}
+}
+
+// TestRunExecutionContextExploreStopsGeneratingOnCancelMidRun is plain Explore's counterpart to
+// TestRunExecutionContextCartesianStopsGeneratingOnCancelMidRun. considered == 2 (not 1) after the
+// first case: nextExplore's lazy corpus seed step and its first loop candidate each check the
+// filter once, both on this first call to next() — see nextExplore's doc comment.
+func TestRunExecutionContextExploreStopsGeneratingOnCancelMidRun(t *testing.T) {
+	var considered, executed int
+	ctx, cancel := context.WithCancel(context.Background())
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 999}}},
+		[]PathFilter{func(PathValues) bool { considered++; return true }}, 0, 0, false, 5, 0, 0)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { executed++; cancel() }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal = %v, want canceled", result.Terminal)
+	}
+	if executed != 1 {
+		t.Fatalf("executed = %d, want exactly 1 (canceled from inside the first case)", executed)
+	}
+	if considered != 2 {
+		t.Fatalf("candidates considered = %d, want 2 (seed + first candidate) — generation must not run ahead of execution", considered)
+	}
+}
+
 func TestGeneratedFatalUsesRealSubtestBoundary(t *testing.T) {
 	if os.Getenv("GO_SPECS_FATAL_BOUNDARY_HELPER") == "1" {
 		var afterRuns int

--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -327,6 +327,16 @@ type pathSequence struct {
 	sampleExecuted    int
 	sampleAttempts    int
 	sampleMaxAttempts int
+
+	// Explore (plain strategy only): mirrors runPlainExploration's state one call to next() at a
+	// time. exploreCorpus/exploreSeenSigs are local to this sequence rather than g.corpus/
+	// g.seenSigs — those remain owned by the ForEach/runPlainExploration path so a direct ForEach
+	// call and an incremental sequence() walk never share (and corrupt) the same corpus. The
+	// filter-retry loop is internal to nextExplore, same as nextSample.
+	exploreSeeded   bool
+	exploreExecuted int
+	exploreCorpus   []PathValues
+	exploreSeenSigs map[uint64]struct{}
 }
 
 // sequence returns a pathSequence for g. Panics if g uses a mode sequence() doesn't support yet.
@@ -354,8 +364,18 @@ func (g *PathGenerator) sequence() *pathSequence {
 			seq.done = true
 		}
 		return seq
+	case ExplorationGuided:
+		if g.strategy != strategyPlain {
+			panic("specs: PathGenerator.sequence supports plain Explore only for ExplorationGuided; ExploreCoverage/ExploreSmart land in a later change")
+		}
+		seq.exploreCorpus = make([]PathValues, 0, g.iterations/10+1)
+		seq.exploreSeenSigs = make(map[uint64]struct{})
+		if g.iterations <= 0 {
+			seq.done = true
+		}
+		return seq
 	default:
-		panic("specs: PathGenerator.sequence supports CartesianMode/SamplingMode only; Explore lands in a later change")
+		panic("specs: PathGenerator.sequence supports CartesianMode/SamplingMode/plain Explore only")
 	}
 }
 
@@ -379,6 +399,9 @@ func (s *pathSequence) next() (PathValues, bool) {
 	}
 	if s.g.mode == SamplingMode {
 		return s.nextSample()
+	}
+	if s.g.mode == ExplorationGuided {
+		return s.nextExplore()
 	}
 	return s.nextFiltered()
 }
@@ -414,6 +437,53 @@ func (s *pathSequence) nextSample() (PathValues, bool) {
 		}
 		s.sampleExecuted++
 		return pv, true
+	}
+}
+
+// nextExplore mirrors runPlainExploration: seed the corpus with one random candidate (if it
+// passes filters), then on each call either mutate a random corpus entry (70% of the time, once
+// the corpus is non-empty) or draw a fully random candidate, retrying internally against filters.
+// captureSignature() is called from this fixed call site for every candidate in the sequence, so
+// — same as runPlainExploration calling it from its own fixed loop line — it yields the same
+// signature every time within one sequence, meaning exploreCorpus only ever grows by the seed
+// candidate plus the first accepted candidate from this loop. That's an existing, documented
+// heuristic limitation (see runGuidedExploration's doc comment), not something introduced here;
+// this method preserves it exactly rather than changing observable behavior.
+func (s *pathSequence) nextExplore() (PathValues, bool) {
+	g := s.g
+	if !s.exploreSeeded {
+		s.exploreSeeded = true
+		var seed PathValues
+		seed.reset(g.index)
+		for i := range g.dims {
+			seed.present[g.dims[i].idx] = true
+			seed.values[g.dims[i].idx] = g.dims[i].randomValue(g.rng)
+		}
+		if g.allow(seed) {
+			s.exploreCorpus = append(s.exploreCorpus, seed.clone())
+		}
+	}
+	if s.exploreExecuted >= g.iterations {
+		s.done = true
+		return PathValues{}, false
+	}
+	for {
+		var candidate PathValues
+		if len(s.exploreCorpus) > 0 && g.rng.Float64() > 0.3 {
+			candidate = g.mutate(s.exploreCorpus[g.rng.Intn(len(s.exploreCorpus))])
+		} else {
+			candidate = g.randomInput()
+		}
+		if !g.allow(candidate) {
+			continue
+		}
+		s.exploreExecuted++
+		sig := captureSignature()
+		if _, seen := s.exploreSeenSigs[sig]; !seen {
+			s.exploreSeenSigs[sig] = struct{}{}
+			s.exploreCorpus = append(s.exploreCorpus, candidate.clone())
+		}
+		return candidate, true
 	}
 }
 
@@ -467,10 +537,13 @@ func (s *pathSequence) advance() bool {
 }
 
 // admitFeedback reports the real outcome of executing candidate back to the generator. It is a
-// no-op for Cartesian and Sample: neither strategy has feedback-dependent state — Sample's
-// candidates are drawn independently of prior results, same as runSamples always was.
-// Explore/ExploreCoverage/ExploreSmart will use it to move corpus/seen-state growth to after the
-// real case runs, once those strategies gain sequence() support.
+// no-op for Cartesian, Sample, and plain Explore: none of the three have feedback-dependent state.
+// Sample's candidates are drawn independently of prior results, same as runSamples always was.
+// Plain Explore's corpus growth is driven by captureSignature()'s call-site novelty proxy inside
+// nextExplore, not by whether the candidate passed — so admitFeedback has nothing to do for it
+// either, even though it now runs after the real case (see nextExplore's doc comment). Genuinely
+// reacting to passed here would require ExploreCoverage/ExploreSmart's real coverage wiring (see
+// runGuidedExploration's doc comment), which those two strategies still lack.
 func (s *pathSequence) admitFeedback(candidate PathValues, passed bool) {}
 
 // bounds returns conservative (never-underestimating) MaxAttempts/MaxAccepted/MaxRejections
@@ -495,8 +568,18 @@ func (g *PathGenerator) bounds() (maxAttempts, maxAccepted, maxRejections int) {
 			return 0, 0, 0
 		}
 		return g.samples, g.samples, g.samples
+	case ExplorationGuided:
+		// Same reasoning as SamplingMode: nextExplore's filter retries are internal and never
+		// surface as separate Propose calls, so g.iterations is exact.
+		if g.strategy != strategyPlain {
+			panic("specs: PathGenerator.bounds supports plain Explore only for ExplorationGuided; ExploreCoverage/ExploreSmart land in a later change")
+		}
+		if g.iterations <= 0 {
+			return 0, 0, 0
+		}
+		return g.iterations, g.iterations, g.iterations
 	default:
-		panic("specs: PathGenerator.bounds supports CartesianMode/SamplingMode only; Explore lands in a later change")
+		panic("specs: PathGenerator.bounds supports CartesianMode/SamplingMode/plain Explore only")
 	}
 }
 
@@ -620,16 +703,17 @@ func (g *PathGenerator) runExploration(fn func(PathValues)) {
 //
 // Real coverage-guided corpus growth needs ctx.coverage populated with genuine assertion-level
 // edge data on every iteration, which requires wiring the runner to set it per path iteration —
-// not yet done. Cartesian and Sampling dispatch from the top-level Describe execution path are
-// incremental (runExecutionContext drives them through PathGenerator.sequence(), one candidate at
-// a time, only admitting feedback after the real case has run); ExplorationGuided — this method's
-// strategies (Coverage/Smart) included — still goes through this ForEach-driven path, fully
-// generated before the runner executes a single case, so corpus growth here still can't depend on
-// a real per-iteration result. Until sequence()/admitFeedback() cover this mode too, corpus growth
-// uses the same call-site-signature novelty heuristic the plain strategy already uses
-// (captureSignature) as an honest, documented proxy — good enough to give NextInput something to
-// mutate from instead of always falling back to fully random input, but not genuine
-// coverage-guided selection.
+// not yet done. Cartesian, Sampling, and plain Explore dispatch from the top-level Describe
+// execution path are all incremental now (runExecutionContext drives them through
+// PathGenerator.sequence(), one candidate at a time, only admitting feedback after the real case
+// has run — see nextExplore for the plain strategy); ExploreCoverage/ExploreSmart — this method's
+// strategies — still go through this ForEach-driven path, fully generated before the runner
+// executes a single case, so corpus growth here still can't depend on a real per-iteration result.
+// Until sequence()/bounds() cover these two strategies too, corpus growth uses the same
+// call-site-signature novelty heuristic the plain strategy uses (captureSignature, now in
+// nextExplore) as an honest, documented proxy — good enough to give NextInput something to mutate
+// from instead of always falling back to fully random input, but not genuine coverage-guided
+// selection.
 func (g *PathGenerator) runGuidedExploration(fn func(PathValues), nextInput func(*PathGenerator) PathValues, corpus *Corpus) {
 	executed := 0
 	for executed < g.iterations {

--- a/specs/path_generator_test.go
+++ b/specs/path_generator_test.go
@@ -104,9 +104,13 @@ func TestPathGeneratorBoundsIsConservativeUpperBound(t *testing.T) {
 }
 
 func TestPathSequencePanicsForUnsupportedModes(t *testing.T) {
-	explore := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2, 3}}}, nil, 0, 0, false, 5, 0, 0)
-	assertPanics(t, func() { explore.sequence() })
-	assertPanics(t, func() { explore.bounds() })
+	coverage := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2, 3}}}, nil, 0, 0, false, 0, 5, 0)
+	assertPanics(t, func() { coverage.sequence() })
+	assertPanics(t, func() { coverage.bounds() })
+
+	smart := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2, 3}}}, nil, 0, 0, false, 0, 0, 5)
+	assertPanics(t, func() { smart.sequence() })
+	assertPanics(t, func() { smart.bounds() })
 }
 
 func TestPathSequenceSampleEmitsExactlyRequestedCount(t *testing.T) {
@@ -186,6 +190,94 @@ func TestPathSequenceSampleAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
 		return newPathGenerator([]PathVar{
 			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
 		}, nil, 5, 7, true, 0, 0, 0)
+	}
+
+	baseline := collectSequence(newGen())
+
+	gen := newGen()
+	seq := gen.sequence()
+	var withFeedback []string
+	for {
+		pv, ok := seq.next()
+		if !ok {
+			break
+		}
+		withFeedback = append(withFeedback, gen.FormatPathValuesForReport(pv))
+		seq.admitFeedback(pv, withFeedback != nil)
+	}
+	if !reflect.DeepEqual(baseline, withFeedback) {
+		t.Fatalf("admitFeedback altered the sequence: got %v, want %v", withFeedback, baseline)
+	}
+}
+
+func TestPathSequenceExploreEmitsExactlyRequestedIterations(t *testing.T) {
+	const iterations = 8
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 100}},
+	}, nil, 0, 0, false, iterations, 0, 0)
+
+	got := collectSequence(gen)
+	if len(got) != iterations {
+		t.Fatalf("len(got) = %d, want %d", len(got), iterations)
+	}
+}
+
+func TestPathSequenceExploreMatchesForEachForSameSeed(t *testing.T) {
+	newGen := func() *PathGenerator {
+		return newPathGenerator([]PathVar{
+			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+		}, nil, 0, 42, true, 6, 0, 0)
+	}
+
+	got := collectSequence(newGen())
+	want := collectForEach(newGen())
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sequence-based explore = %v, want %v (must match runPlainExploration exactly for the same seed)", got, want)
+	}
+}
+
+func TestPathSequenceExploreRespectsFilters(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 20}},
+	}, []PathFilter{func(pv PathValues) bool {
+		v, _ := pv.lookup("x")
+		return v.(int)%2 == 0
+	}}, 0, 0, false, 7, 0, 0)
+
+	seq := gen.sequence()
+	for i := 0; i < 7; i++ {
+		pv, ok := seq.next()
+		if !ok {
+			t.Fatalf("expected candidate %d, got exhaustion", i)
+		}
+		if pv.Int("x")%2 != 0 {
+			t.Fatalf("expected even x, got %d", pv.Int("x"))
+		}
+	}
+	if _, ok := seq.next(); ok {
+		t.Fatal("expected exhaustion after 7 accepted candidates")
+	}
+}
+
+func TestPathSequenceExploreBoundsIsExact(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 100}},
+	}, nil, 0, 0, false, 9, 0, 0)
+
+	maxAttempts, maxAccepted, maxRejections := gen.bounds()
+	if maxAttempts != 9 || maxAccepted != 9 || maxRejections != 9 {
+		t.Fatalf("bounds = (%d, %d, %d), want (9, 9, 9)", maxAttempts, maxAccepted, maxRejections)
+	}
+	if got := len(collectSequence(gen)); got != maxAccepted {
+		t.Fatalf("actual accepted candidates = %d, want exactly %d", got, maxAccepted)
+	}
+}
+
+func TestPathSequenceExploreAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
+	newGen := func() *PathGenerator {
+		return newPathGenerator([]PathVar{
+			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+		}, nil, 0, 7, true, 6, 0, 0)
 	}
 
 	baseline := collectSequence(newGen())


### PR DESCRIPTION
## Summary

PR2 of the #43 migration series (PR1: #50, Sample incremental). Extends `pathSequence`/`bounds()` to cover plain Explore (`.Explore(n)`, `strategyPlain`), so `runExecutionContext` now drives Cartesian, Sample, **and** plain Explore through the same incremental `sequence()`/`next()`/`admitFeedback()` contract — one candidate generated only after the previous one has actually executed, instead of materializing the whole batch via `ForEach`/`[]PathValues` up front.

`ExploreCoverage`/`ExploreSmart` are explicitly out of scope for this PR (per plan: PR3) and are untouched — they still go through `runGuidedExploration`'s `ForEach` fallback.

## Design notes

- **`pathSequence.nextExplore()`** mirrors `runPlainExploration` exactly: seeds a corpus entry from one random candidate (if it passes filters), then on each call either mutates a random corpus entry (70% of the time once the corpus is non-empty) or draws a fully random candidate, retrying internally against filters — never surfacing rejected attempts to the `proposalController` as separate `Propose` calls, same discipline as Sample's `nextSample()`.
- **`captureSignature()` quirk preserved on purpose.** It hashes the call stack, not the candidate's value — an existing, already-documented heuristic limitation (see `runGuidedExploration`'s doc comment). Since `nextExplore()` calls it from one fixed line for the life of the sequence, the signature is identical on every call within one sequence, so the corpus only ever grows by the seed candidate plus the first accepted candidate from the loop — exactly the batch implementation's behavior. `TestPathSequenceExploreMatchesForEachForSameSeed` locks this down by diffing the incremental path's output against `ForEach`'s for the same seed.
- **`bounds()`** returns `(iterations, iterations, iterations)` — exact, not conservative, for the same reason as Sample: internal filter retries never surface as separate proposals.
- **`admitFeedback()`** stays a no-op for plain Explore. Corpus growth is driven by the signature proxy, not by whether the candidate passed, so there's nothing for it to react to yet — genuinely reacting to pass/fail still needs `ExploreCoverage`/`ExploreSmart`'s real coverage wiring (unrelated to this PR).
- `ForEach`/`runPlainExploration` are untouched and still used directly by `explore_mode_selection_test.go`; they keep their own `g.corpus`/`g.seenSigs` state, independent from `pathSequence`'s local copies, so the two paths never cross-contaminate each other's corpus.

## Changed files

- `specs/path_generator.go` — `pathSequence` gains Explore-local state (`exploreSeeded`, `exploreExecuted`, `exploreCorpus`, `exploreSeenSigs`); `sequence()`/`next()`/`bounds()` gain an `ExplorationGuided`+`strategyPlain` branch; new `nextExplore()`; `admitFeedback()` and `runGuidedExploration()` doc comments updated.
- `specs/execution_plan.go` — `runExecutionContext`'s incremental-dispatch guard now also matches `ExplorationGuided`+`strategyPlain`; fallback comment updated to say only ExploreCoverage/ExploreSmart remain on it.
- `specs/path_generator_test.go` — `TestPathSequencePanicsForUnsupportedModes` now asserts on ExploreCoverage/ExploreSmart instead of plain Explore (which no longer panics); 5 new tests mirroring PR1's Sample coverage (exact iteration count, ForEach parity for the same seed, filter respect, exact bounds, admitFeedback no-op).
- `specs/execution_plan_test.go` — 2 new cancellation tests mirroring Sample's, proving no upfront materialization for plain Explore. The mid-run variant expects `considered == 2` (not 1) because `nextExplore`'s lazy corpus seed step and its first loop candidate each check the filter once on the very first `next()` call.

## Evidence: no upfront materialization

`TestRunExecutionContextExploreDoesNotMaterializeUnderCancellation` / `...StopsGeneratingOnCancelMidRun` — same shape as the existing Cartesian/Sample tests, proving cancellation stops generation immediately rather than only stopping dispatch of an already-generated batch.

## Validation

- `gofmt -l` — clean on all touched files
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all green (18 packages)
- `go test ./specs/... -race` — clean
- `make build` / `make lint` — clean (0 issues)

## Debt for PR3

- ExploreCoverage/ExploreSmart still fully on the `ForEach` fallback — no `sequence()`/`bounds()` support yet.
- `CoverageExplorer.Feedback`/`SmartExplorer.Feedback` remain unwired, as agreed — that decision (part of #43 vs. separate issue) is deferred to PR3.
- Real per-iteration coverage (`ctx.coverage`) still isn't wired to the runner; PR3's corpus growth will still need the signature-proxy heuristic until that lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
