### PR TITLE
feat(specs): migrate ExploreCoverage/ExploreSmart to incremental execution

### DIFF
--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -205,7 +205,7 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 	incrementalCapable := i < len(plan.PathGens) && plan.PathGens[i] != nil &&
 		(plan.PathGens[i].mode == CartesianMode ||
 			plan.PathGens[i].mode == SamplingMode ||
-			(plan.PathGens[i].mode == ExplorationGuided && plan.PathGens[i].strategy == strategyPlain))
+			plan.PathGens[i].mode == ExplorationGuided)
 	if incrementalCapable {
 		gen := plan.PathGens[i]
 		seq := gen.sequence()
@@ -224,8 +224,9 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 		}).Run(runCtx)
 	}
 	if i < len(plan.PathGens) && plan.PathGens[i] != nil {
-		// ExploreCoverage/ExploreSmart still materialize via ForEach until a later change extends
-		// sequence()/bounds() to those two guided strategies (see path_generator.go).
+		// Unreachable now that incrementalCapable covers every ExplorationMode value (Cartesian,
+		// Sampling, and all three ExplorationGuided strategies) — kept until a later change removes
+		// this ForEach/[]PathValues batch fallback entirely and closes #43.
 		paths := make([]PathValues, 0)
 		plan.PathGens[i].ForEach(func(path PathValues) { paths = append(paths, path.clone()) })
 		next := 0

--- a/specs/execution_plan_test.go
+++ b/specs/execution_plan_test.go
@@ -332,6 +332,99 @@ func TestRunExecutionContextExploreStopsGeneratingOnCancelMidRun(t *testing.T) {
 	}
 }
 
+// TestRunExecutionContextCoverageDoesNotMaterializeUnderCancellation is ExploreCoverage's
+// counterpart to TestRunExecutionContextCartesianDoesNotMaterializeUnderCancellation: proves
+// runExecutionContext no longer routes strategyCoverage ExplorationGuided through the ForEach/
+// []PathValues fallback, which would have generated every iteration (and run every filter) before
+// the controller ever observed cancellation.
+func TestRunExecutionContextCoverageDoesNotMaterializeUnderCancellation(t *testing.T) {
+	var considered int
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 999}}},
+		[]PathFilter{func(PathValues) bool { considered++; return true }}, 0, 0, false, 0, 5, 0)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { t.Fatal("body must not run") }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal = %v, want canceled", result.Terminal)
+	}
+	if considered != 0 {
+		t.Fatalf("candidates considered before the controller observed cancellation = %d, want 0", considered)
+	}
+}
+
+// TestRunExecutionContextCoverageStopsGeneratingOnCancelMidRun is ExploreCoverage's counterpart to
+// TestRunExecutionContextCartesianStopsGeneratingOnCancelMidRun. Unlike Explore's nextExplore,
+// nextGuided has no separate seed step (runGuidedExploration doesn't have one either), so
+// considered == 1 here, not 2.
+func TestRunExecutionContextCoverageStopsGeneratingOnCancelMidRun(t *testing.T) {
+	var considered, executed int
+	ctx, cancel := context.WithCancel(context.Background())
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 999}}},
+		[]PathFilter{func(PathValues) bool { considered++; return true }}, 0, 0, false, 0, 5, 0)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { executed++; cancel() }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal = %v, want canceled", result.Terminal)
+	}
+	if executed != 1 {
+		t.Fatalf("executed = %d, want exactly 1 (canceled from inside the first case)", executed)
+	}
+	if considered != 1 {
+		t.Fatalf("candidates considered = %d, want 1 — generation must not run ahead of execution", considered)
+	}
+}
+
+// TestRunExecutionContextSmartDoesNotMaterializeUnderCancellation is ExploreSmart's counterpart to
+// TestRunExecutionContextCartesianDoesNotMaterializeUnderCancellation.
+func TestRunExecutionContextSmartDoesNotMaterializeUnderCancellation(t *testing.T) {
+	var considered int
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 999}}},
+		[]PathFilter{func(PathValues) bool { considered++; return true }}, 0, 0, false, 0, 0, 5)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { t.Fatal("body must not run") }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal = %v, want canceled", result.Terminal)
+	}
+	if considered != 0 {
+		t.Fatalf("candidates considered before the controller observed cancellation = %d, want 0", considered)
+	}
+}
+
+// TestRunExecutionContextSmartStopsGeneratingOnCancelMidRun is ExploreSmart's counterpart to
+// TestRunExecutionContextCartesianStopsGeneratingOnCancelMidRun.
+func TestRunExecutionContextSmartStopsGeneratingOnCancelMidRun(t *testing.T) {
+	var considered, executed int
+	ctx, cancel := context.WithCancel(context.Background())
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 999}}},
+		[]PathFilter{func(PathValues) bool { considered++; return true }}, 0, 0, false, 0, 0, 5)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(*Context) { executed++; cancel() }}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	result := runExecutionContext(ctx, &controlledBackend{}, nil, plan, 0)
+	if result.Terminal != proposalTerminalCanceled {
+		t.Fatalf("terminal = %v, want canceled", result.Terminal)
+	}
+	if executed != 1 {
+		t.Fatalf("executed = %d, want exactly 1 (canceled from inside the first case)", executed)
+	}
+	if considered != 1 {
+		t.Fatalf("candidates considered = %d, want 1 — generation must not run ahead of execution", considered)
+	}
+}
+
 func TestGeneratedFatalUsesRealSubtestBoundary(t *testing.T) {
 	if os.Getenv("GO_SPECS_FATAL_BOUNDARY_HELPER") == "1" {
 		var afterRuns int

--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -306,8 +306,8 @@ func (g *PathGenerator) FillPathValues(index []int, pv *PathValues) {
 // the generator afterward, so guided strategies can update corpus/novelty state only once the
 // real case has actually run.
 //
-// CartesianMode and SamplingMode are supported so far; Explore/ExploreCoverage/ExploreSmart still
-// go through ForEach until a later change extends sequence()/bounds() to those strategies.
+// CartesianMode, SamplingMode, and all three ExplorationGuided strategies (Explore/ExploreCoverage/
+// ExploreSmart) are supported.
 type pathSequence struct {
 	g       *PathGenerator
 	done    bool
@@ -337,6 +337,17 @@ type pathSequence struct {
 	exploreExecuted int
 	exploreCorpus   []PathValues
 	exploreSeenSigs map[uint64]struct{}
+
+	// ExploreCoverage/ExploreSmart: mirrors runGuidedExploration's state one call to next() at a
+	// time. Unlike exploreSeenSigs above, guidedSeenSigs is the only local copy needed — NextInput
+	// is a fixed method on CoverageExplorer/SmartExplorer that always reads that explorer's own
+	// e.corpus field, so corpus growth must write directly into g.coverageExplorer.corpus /
+	// g.smartExplorer.corpus (the same real corpus runGuidedExploration grows) rather than a local
+	// copy; there is no g.corpus-equivalent field to avoid contaminating for these two strategies.
+	// guidedSeenSigs stays local so a direct ForEach call and an incremental sequence() walk never
+	// share (and corrupt) the same signature set — same discipline as exploreSeenSigs vs g.seenSigs.
+	guidedExecuted int
+	guidedSeenSigs map[uint64]struct{}
 }
 
 // sequence returns a pathSequence for g. Panics if g uses a mode sequence() doesn't support yet.
@@ -365,17 +376,19 @@ func (g *PathGenerator) sequence() *pathSequence {
 		}
 		return seq
 	case ExplorationGuided:
-		if g.strategy != strategyPlain {
-			panic("specs: PathGenerator.sequence supports plain Explore only for ExplorationGuided; ExploreCoverage/ExploreSmart land in a later change")
+		switch g.strategy {
+		case strategyPlain:
+			seq.exploreCorpus = make([]PathValues, 0, g.iterations/10+1)
+			seq.exploreSeenSigs = make(map[uint64]struct{})
+		case strategyCoverage, strategySmart:
+			seq.guidedSeenSigs = make(map[uint64]struct{})
 		}
-		seq.exploreCorpus = make([]PathValues, 0, g.iterations/10+1)
-		seq.exploreSeenSigs = make(map[uint64]struct{})
 		if g.iterations <= 0 {
 			seq.done = true
 		}
 		return seq
 	default:
-		panic("specs: PathGenerator.sequence supports CartesianMode/SamplingMode/plain Explore only")
+		panic("specs: PathGenerator.sequence supports CartesianMode/SamplingMode/ExplorationGuided only")
 	}
 }
 
@@ -401,7 +414,10 @@ func (s *pathSequence) next() (PathValues, bool) {
 		return s.nextSample()
 	}
 	if s.g.mode == ExplorationGuided {
-		return s.nextExplore()
+		if s.g.strategy == strategyPlain {
+			return s.nextExplore()
+		}
+		return s.nextGuided()
 	}
 	return s.nextFiltered()
 }
@@ -487,6 +503,44 @@ func (s *pathSequence) nextExplore() (PathValues, bool) {
 	}
 }
 
+// nextGuided mirrors runGuidedExploration exactly for strategyCoverage/strategySmart: draw a
+// candidate from the CoverageExplorer's/SmartExplorer's own NextInput, retry internally against
+// filters, and on acceptance grow that explorer's own corpus via the same captureSignature()
+// call-site novelty proxy runGuidedExploration already uses — see that method's doc comment for why
+// the proxy, not real per-iteration coverage, still drives corpus growth here. Unlike nextExplore,
+// there is no separate seed step: runGuidedExploration doesn't have one either, so growth caps at
+// exactly one corpus entry (the first accepted candidate) rather than two.
+func (s *pathSequence) nextGuided() (PathValues, bool) {
+	g := s.g
+	if s.guidedExecuted >= g.iterations {
+		s.done = true
+		return PathValues{}, false
+	}
+	var nextInput func(*PathGenerator) PathValues
+	var corpus *Corpus
+	switch g.strategy {
+	case strategyCoverage:
+		nextInput = g.coverageExplorer.NextInput
+		corpus = g.coverageExplorer.corpus
+	case strategySmart:
+		nextInput = g.smartExplorer.NextInput
+		corpus = g.smartExplorer.corpus
+	}
+	for {
+		candidate := nextInput(g)
+		if !g.allow(candidate) {
+			continue
+		}
+		s.guidedExecuted++
+		sig := captureSignature()
+		if _, seen := s.guidedSeenSigs[sig]; !seen {
+			s.guidedSeenSigs[sig] = struct{}{}
+			corpus.Add(candidate)
+		}
+		return candidate, true
+	}
+}
+
 // nextFiltered mirrors enumerate()'s odometer, yielding one allowed combination per call instead
 // of visiting the whole space up front.
 func (s *pathSequence) nextFiltered() (PathValues, bool) {
@@ -537,13 +591,14 @@ func (s *pathSequence) advance() bool {
 }
 
 // admitFeedback reports the real outcome of executing candidate back to the generator. It is a
-// no-op for Cartesian, Sample, and plain Explore: none of the three have feedback-dependent state.
+// no-op for all five supported mode/strategy combinations: none has feedback-dependent state today.
 // Sample's candidates are drawn independently of prior results, same as runSamples always was.
-// Plain Explore's corpus growth is driven by captureSignature()'s call-site novelty proxy inside
-// nextExplore, not by whether the candidate passed — so admitFeedback has nothing to do for it
-// either, even though it now runs after the real case (see nextExplore's doc comment). Genuinely
-// reacting to passed here would require ExploreCoverage/ExploreSmart's real coverage wiring (see
-// runGuidedExploration's doc comment), which those two strategies still lack.
+// Explore/ExploreCoverage/ExploreSmart's corpus growth is driven by captureSignature()'s call-site
+// novelty proxy inside nextExplore/nextGuided, not by whether the candidate passed — so
+// admitFeedback has nothing to do for any of them, even though it now runs after the real case (see
+// nextExplore's/nextGuided's doc comments). Genuinely reacting to passed for ExploreCoverage/
+// ExploreSmart would require wiring real per-iteration coverage into Feedback (see
+// runGuidedExploration's doc comment) — deliberately out of scope for this migration; see #43.
 func (s *pathSequence) admitFeedback(candidate PathValues, passed bool) {}
 
 // bounds returns conservative (never-underestimating) MaxAttempts/MaxAccepted/MaxRejections
@@ -569,17 +624,15 @@ func (g *PathGenerator) bounds() (maxAttempts, maxAccepted, maxRejections int) {
 		}
 		return g.samples, g.samples, g.samples
 	case ExplorationGuided:
-		// Same reasoning as SamplingMode: nextExplore's filter retries are internal and never
-		// surface as separate Propose calls, so g.iterations is exact.
-		if g.strategy != strategyPlain {
-			panic("specs: PathGenerator.bounds supports plain Explore only for ExplorationGuided; ExploreCoverage/ExploreSmart land in a later change")
-		}
+		// Same reasoning as SamplingMode for all three strategies: nextExplore's/nextGuided's
+		// filter retries are internal and never surface as separate Propose calls, so g.iterations
+		// is exact.
 		if g.iterations <= 0 {
 			return 0, 0, 0
 		}
 		return g.iterations, g.iterations, g.iterations
 	default:
-		panic("specs: PathGenerator.bounds supports CartesianMode/SamplingMode/plain Explore only")
+		panic("specs: PathGenerator.bounds supports CartesianMode/SamplingMode/ExplorationGuided only")
 	}
 }
 
@@ -699,21 +752,20 @@ func (g *PathGenerator) runExploration(fn func(PathValues)) {
 	}
 }
 
-// runGuidedExploration drives CoverageExplorer/SmartExplorer for candidate generation.
+// runGuidedExploration drives CoverageExplorer/SmartExplorer for candidate generation. It backs
+// ForEach()/runExploration() — the compatibility path exercised directly by callers like
+// explore_mode_selection_test.go that construct a PathGenerator and call ForEach without going
+// through the top-level Describe/runExecutionContext dispatch. That dispatch path is fully
+// incremental now for all three ExplorationGuided strategies (see PathGenerator.sequence(),
+// nextExplore for strategyPlain, nextGuided for strategyCoverage/strategySmart) and no longer calls
+// this method at all.
 //
-// Real coverage-guided corpus growth needs ctx.coverage populated with genuine assertion-level
-// edge data on every iteration, which requires wiring the runner to set it per path iteration —
-// not yet done. Cartesian, Sampling, and plain Explore dispatch from the top-level Describe
-// execution path are all incremental now (runExecutionContext drives them through
-// PathGenerator.sequence(), one candidate at a time, only admitting feedback after the real case
-// has run — see nextExplore for the plain strategy); ExploreCoverage/ExploreSmart — this method's
-// strategies — still go through this ForEach-driven path, fully generated before the runner
-// executes a single case, so corpus growth here still can't depend on a real per-iteration result.
-// Until sequence()/bounds() cover these two strategies too, corpus growth uses the same
-// call-site-signature novelty heuristic the plain strategy uses (captureSignature, now in
-// nextExplore) as an honest, documented proxy — good enough to give NextInput something to mutate
-// from instead of always falling back to fully random input, but not genuine coverage-guided
-// selection.
+// Real coverage-guided corpus growth needs ctx.coverage populated with genuine assertion-level edge
+// data on every iteration, which requires wiring the runner to set it per path iteration — not yet
+// done (see nextGuided's doc comment). So, same as nextGuided, this method's corpus growth still
+// uses the call-site-signature novelty heuristic (captureSignature) as an honest, documented proxy —
+// good enough to give NextInput something to mutate from instead of always falling back to fully
+// random input, but not genuine coverage-guided selection.
 func (g *PathGenerator) runGuidedExploration(fn func(PathValues), nextInput func(*PathGenerator) PathValues, corpus *Corpus) {
 	executed := 0
 	for executed < g.iterations {

--- a/specs/path_generator_test.go
+++ b/specs/path_generator_test.go
@@ -103,16 +103,6 @@ func TestPathGeneratorBoundsIsConservativeUpperBound(t *testing.T) {
 	}
 }
 
-func TestPathSequencePanicsForUnsupportedModes(t *testing.T) {
-	coverage := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2, 3}}}, nil, 0, 0, false, 0, 5, 0)
-	assertPanics(t, func() { coverage.sequence() })
-	assertPanics(t, func() { coverage.bounds() })
-
-	smart := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2, 3}}}, nil, 0, 0, false, 0, 0, 5)
-	assertPanics(t, func() { smart.sequence() })
-	assertPanics(t, func() { smart.bounds() })
-}
-
 func TestPathSequenceSampleEmitsExactlyRequestedCount(t *testing.T) {
 	const samples = 7
 	gen := newPathGenerator([]PathVar{
@@ -278,6 +268,182 @@ func TestPathSequenceExploreAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
 		return newPathGenerator([]PathVar{
 			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
 		}, nil, 0, 7, true, 6, 0, 0)
+	}
+
+	baseline := collectSequence(newGen())
+
+	gen := newGen()
+	seq := gen.sequence()
+	var withFeedback []string
+	for {
+		pv, ok := seq.next()
+		if !ok {
+			break
+		}
+		withFeedback = append(withFeedback, gen.FormatPathValuesForReport(pv))
+		seq.admitFeedback(pv, withFeedback != nil)
+	}
+	if !reflect.DeepEqual(baseline, withFeedback) {
+		t.Fatalf("admitFeedback altered the sequence: got %v, want %v", withFeedback, baseline)
+	}
+}
+
+func TestPathSequenceCoverageEmitsExactlyRequestedIterations(t *testing.T) {
+	const iterations = 8
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 100}},
+	}, nil, 0, 0, false, 0, iterations, 0)
+
+	got := collectSequence(gen)
+	if len(got) != iterations {
+		t.Fatalf("len(got) = %d, want %d", len(got), iterations)
+	}
+}
+
+func TestPathSequenceCoverageMatchesForEachForSameSeed(t *testing.T) {
+	newGen := func() *PathGenerator {
+		return newPathGenerator([]PathVar{
+			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+		}, nil, 0, 42, true, 0, 6, 0)
+	}
+
+	got := collectSequence(newGen())
+	want := collectForEach(newGen())
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sequence-based ExploreCoverage = %v, want %v (must match runGuidedExploration exactly for the same seed)", got, want)
+	}
+}
+
+func TestPathSequenceCoverageRespectsFilters(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 20}},
+	}, []PathFilter{func(pv PathValues) bool {
+		v, _ := pv.lookup("x")
+		return v.(int)%2 == 0
+	}}, 0, 0, false, 0, 7, 0)
+
+	seq := gen.sequence()
+	for i := 0; i < 7; i++ {
+		pv, ok := seq.next()
+		if !ok {
+			t.Fatalf("expected candidate %d, got exhaustion", i)
+		}
+		if pv.Int("x")%2 != 0 {
+			t.Fatalf("expected even x, got %d", pv.Int("x"))
+		}
+	}
+	if _, ok := seq.next(); ok {
+		t.Fatal("expected exhaustion after 7 accepted candidates")
+	}
+}
+
+func TestPathSequenceCoverageBoundsIsExact(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 100}},
+	}, nil, 0, 0, false, 0, 9, 0)
+
+	maxAttempts, maxAccepted, maxRejections := gen.bounds()
+	if maxAttempts != 9 || maxAccepted != 9 || maxRejections != 9 {
+		t.Fatalf("bounds = (%d, %d, %d), want (9, 9, 9)", maxAttempts, maxAccepted, maxRejections)
+	}
+	if got := len(collectSequence(gen)); got != maxAccepted {
+		t.Fatalf("actual accepted candidates = %d, want exactly %d", got, maxAccepted)
+	}
+}
+
+func TestPathSequenceCoverageAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
+	newGen := func() *PathGenerator {
+		return newPathGenerator([]PathVar{
+			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+		}, nil, 0, 7, true, 0, 6, 0)
+	}
+
+	baseline := collectSequence(newGen())
+
+	gen := newGen()
+	seq := gen.sequence()
+	var withFeedback []string
+	for {
+		pv, ok := seq.next()
+		if !ok {
+			break
+		}
+		withFeedback = append(withFeedback, gen.FormatPathValuesForReport(pv))
+		seq.admitFeedback(pv, withFeedback != nil)
+	}
+	if !reflect.DeepEqual(baseline, withFeedback) {
+		t.Fatalf("admitFeedback altered the sequence: got %v, want %v", withFeedback, baseline)
+	}
+}
+
+func TestPathSequenceSmartEmitsExactlyRequestedIterations(t *testing.T) {
+	const iterations = 8
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 100}},
+	}, nil, 0, 0, false, 0, 0, iterations)
+
+	got := collectSequence(gen)
+	if len(got) != iterations {
+		t.Fatalf("len(got) = %d, want %d", len(got), iterations)
+	}
+}
+
+func TestPathSequenceSmartMatchesForEachForSameSeed(t *testing.T) {
+	newGen := func() *PathGenerator {
+		return newPathGenerator([]PathVar{
+			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+		}, nil, 0, 42, true, 0, 0, 6)
+	}
+
+	got := collectSequence(newGen())
+	want := collectForEach(newGen())
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sequence-based ExploreSmart = %v, want %v (must match runGuidedExploration exactly for the same seed)", got, want)
+	}
+}
+
+func TestPathSequenceSmartRespectsFilters(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 20}},
+	}, []PathFilter{func(pv PathValues) bool {
+		v, _ := pv.lookup("x")
+		return v.(int)%2 == 0
+	}}, 0, 0, false, 0, 0, 7)
+
+	seq := gen.sequence()
+	for i := 0; i < 7; i++ {
+		pv, ok := seq.next()
+		if !ok {
+			t.Fatalf("expected candidate %d, got exhaustion", i)
+		}
+		if pv.Int("x")%2 != 0 {
+			t.Fatalf("expected even x, got %d", pv.Int("x"))
+		}
+	}
+	if _, ok := seq.next(); ok {
+		t.Fatal("expected exhaustion after 7 accepted candidates")
+	}
+}
+
+func TestPathSequenceSmartBoundsIsExact(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 100}},
+	}, nil, 0, 0, false, 0, 0, 9)
+
+	maxAttempts, maxAccepted, maxRejections := gen.bounds()
+	if maxAttempts != 9 || maxAccepted != 9 || maxRejections != 9 {
+		t.Fatalf("bounds = (%d, %d, %d), want (9, 9, 9)", maxAttempts, maxAccepted, maxRejections)
+	}
+	if got := len(collectSequence(gen)); got != maxAccepted {
+		t.Fatalf("actual accepted candidates = %d, want exactly %d", got, maxAccepted)
+	}
+}
+
+func TestPathSequenceSmartAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
+	newGen := func() *PathGenerator {
+		return newPathGenerator([]PathVar{
+			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+		}, nil, 0, 7, true, 0, 0, 6)
 	}
 
 	baseline := collectSequence(newGen())


### PR DESCRIPTION
## Summary

PR3 of the #43 migration series (PR1: #50 Sample, PR2: #51 plain Explore). Extends `pathSequence`/`bounds()` to cover `ExploreCoverage`/`ExploreSmart` (`strategyCoverage`/`strategySmart`, both `ExplorationGuided`), so `runExecutionContext` now drives **every** mode/strategy combination — Cartesian, Sample, and all three Explore variants — through the same incremental `sequence()`/`next()`/`admitFeedback()` contract.

Scope was decided explicitly for this PR: **same signature proxy as `runGuidedExploration`, `CoverageExplorer.Feedback`/`SmartExplorer.Feedback` stay unwired.** Real per-iteration `ctx.coverage` telemetry is not part of this PR — that's separate, out-of-scope work for genuinely coverage-guided exploration (see Debt below).

## Design notes

- **`pathSequence.nextGuided()`** mirrors `runGuidedExploration` exactly: on each call, draws a candidate from the strategy's own `NextInput` (`CoverageExplorer.NextInput`/`SmartExplorer.NextInput`), retries internally against filters, and on acceptance grows that explorer's own corpus via the same `captureSignature()` call-site novelty proxy `runGuidedExploration` already uses.
- **No local corpus copy, unlike `nextExplore`'s `exploreCorpus`.** `NextInput` is a fixed method on `CoverageExplorer`/`SmartExplorer` that always reads that explorer's own `e.corpus` field — there's no way to keep growth in a sequence-local copy without breaking the mutate/random balance `NextInput` depends on. So `nextGuided` writes directly into `g.coverageExplorer.corpus`/`g.smartExplorer.corpus`, the same real corpus `runGuidedExploration` grows.
- **`guidedSeenSigs` stays local**, independent from `g.seenSigs` (which `runGuidedExploration` uses) — so a direct `ForEach` call and an incremental `sequence()` walk never share (and corrupt) the same signature set. Same discipline as `exploreSeenSigs` vs `g.seenSigs` from PR2.
- **No separate seed step**, unlike `nextExplore`. `runGuidedExploration` doesn't seed the corpus before its loop either — `NextInput` already falls back to random when the corpus is empty. So corpus growth caps at exactly one entry (the first accepted candidate), not two.
- **`bounds()`** now returns `(iterations, iterations, iterations)` uniformly for all three `ExplorationGuided` strategies — the panic for unsupported strategies is gone since there's nothing left unsupported.
- **`admitFeedback()`** stays a no-op for these two strategies too, same reasoning as Sample/plain Explore: corpus growth is driven by the signature proxy, not by whether the candidate passed.
- `ForEach`/`runGuidedExploration`/`runExploration` are untouched and still used directly by `explore_mode_selection_test.go` and any other direct caller.
- `runExecutionContext`'s old `ForEach`/`[]PathValues` batch-fallback branch is now unreachable for any non-nil `PathGens[i]` (every `ExplorationMode` value is `incrementalCapable`) — left in place with an updated comment; removing it is PR4's job, along with closing #43.

## Changed files

- `specs/path_generator.go` — `pathSequence` gains `guidedExecuted`/`guidedSeenSigs`; `sequence()`/`next()`/`bounds()` extended to `strategyCoverage`/`strategySmart` (panics removed, nothing left unsupported); new `nextGuided()`; `admitFeedback()` and `runGuidedExploration()` doc comments updated.
- `specs/execution_plan.go` — `runExecutionContext`'s incremental-dispatch guard now matches any `ExplorationGuided` strategy; fallback branch comment updated to note it's now unreachable pending PR4's removal.
- `specs/path_generator_test.go` — removed `TestPathSequencePanicsForUnsupportedModes` (nothing panics anymore); added 10 new tests (5 each for Coverage/Smart) mirroring PR1/PR2's pattern: exact iteration count, ForEach parity for the same seed, filter respect, exact bounds, admitFeedback no-op.
- `specs/execution_plan_test.go` — 4 new cancellation tests (2 each for Coverage/Smart) mirroring Cartesian/Sample's shape. Both mid-run variants expect `considered == 1` (not 2, unlike Explore) since `nextGuided` has no separate seed step.

## Evidence: no upfront materialization

`TestRunExecutionContext{Coverage,Smart}DoesNotMaterializeUnderCancellation` / `...StopsGeneratingOnCancelMidRun` — same shape as the existing Cartesian/Sample/Explore tests, proving cancellation stops generation immediately for both guided strategies.

## Validation

- `gofmt -l` — clean on all touched files
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all green (all packages)
- `go test ./specs/... -race` — clean
- `make build` / `make lint` — clean (0 issues)

## Debt for PR4

- The `ForEach`/`[]PathValues` batch-fallback branch in `runExecutionContext` is now dead code — remove it entirely and close #43.
- The two reporting-gated skipped tests in `paths_test.go` are unrelated to #43 (confirmed in the original investigation) — should be unaffected by PR4.

## Separately tracked (not #43)

- `CoverageExplorer.Feedback`/`SmartExplorer.Feedback` remain unwired. Real per-iteration coverage (`ctx.coverage`, `RecordCoverage`) still isn't wired to the runner — genuinely coverage-guided exploration is separate, follow-up work, not part of eliminating the batch fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
