### PR TITLE
refactor(specs): remove dead batch fallback, close #43

### DIFF
--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -202,11 +202,7 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 		return proposalControllerResult{}
 	}
 	program := plan.Instructions[start : start+length]
-	incrementalCapable := i < len(plan.PathGens) && plan.PathGens[i] != nil &&
-		(plan.PathGens[i].mode == CartesianMode ||
-			plan.PathGens[i].mode == SamplingMode ||
-			plan.PathGens[i].mode == ExplorationGuided)
-	if incrementalCapable {
+	if i < len(plan.PathGens) && plan.PathGens[i] != nil {
 		gen := plan.PathGens[i]
 		seq := gen.sequence()
 		maxAttempts, maxAccepted, maxRejections := gen.bounds()
@@ -222,31 +218,6 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 				seq.admitFeedback(feedback.Candidate.Values, feedback.Passed)
 			},
 		}).Run(runCtx)
-	}
-	if i < len(plan.PathGens) && plan.PathGens[i] != nil {
-		// Unreachable now that incrementalCapable covers every ExplorationMode value (Cartesian,
-		// Sampling, and all three ExplorationGuided strategies) — kept until a later change removes
-		// this ForEach/[]PathValues batch fallback entirely and closes #43.
-		paths := make([]PathValues, 0)
-		plan.PathGens[i].ForEach(func(path PathValues) { paths = append(paths, path.clone()) })
-		next := 0
-		result := newProposalController(proposalControllerConfig{
-			MaxAttempts:   len(paths),
-			MaxAccepted:   len(paths),
-			MaxRejections: len(paths),
-			Propose: func() (PathValues, bool) {
-				if next == len(paths) {
-					return PathValues{}, false
-				}
-				path := paths[next]
-				next++
-				return path, true
-			},
-			Execute: func(candidate proposalCandidate) bool {
-				return !runIsolatedCase(backend, program, candidate.Values).Failed
-			},
-		}).Run(runCtx)
-		return result
 	}
 	ctx := contextPool.Get().(*Context)
 	defer func() {

--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -350,7 +350,9 @@ type pathSequence struct {
 	guidedSeenSigs map[uint64]struct{}
 }
 
-// sequence returns a pathSequence for g. Panics if g uses a mode sequence() doesn't support yet.
+// sequence returns a pathSequence for g, incremental for every ExplorationMode (Cartesian,
+// Sampling, and all three ExplorationGuided strategies). The panic below is a defensive guard
+// against an invalid ExplorationMode value, not a real gap.
 func (g *PathGenerator) sequence() *pathSequence {
 	seq := &pathSequence{g: g}
 	if g == nil || len(g.vars) == 0 || len(g.index) == 0 {
@@ -602,8 +604,9 @@ func (s *pathSequence) advance() bool {
 func (s *pathSequence) admitFeedback(candidate PathValues, passed bool) {}
 
 // bounds returns conservative (never-underestimating) MaxAttempts/MaxAccepted/MaxRejections
-// upper bounds for proposalControllerConfig, computed without generating a single candidate.
-// Panics if g uses a mode sequence()/bounds() doesn't support yet.
+// upper bounds for proposalControllerConfig, computed without generating a single candidate, for
+// every ExplorationMode. The panic below is a defensive guard against an invalid ExplorationMode
+// value, not a real gap.
 func (g *PathGenerator) bounds() (maxAttempts, maxAccepted, maxRejections int) {
 	if g == nil || len(g.vars) == 0 || len(g.index) == 0 {
 		return 1, 1, 1
@@ -636,7 +639,10 @@ func (g *PathGenerator) bounds() (maxAttempts, maxAccepted, maxRejections int) {
 	}
 }
 
-// ForEach iterates over every allowed combination in declaration order.
+// ForEach iterates over every allowed combination in declaration order. It's a direct, standalone
+// API for callers that construct a PathGenerator themselves (e.g. explore_mode_selection_test.go) —
+// runExecutionContext no longer calls it; the top-level Describe/Paths execution path is fully
+// incremental via PathGenerator.sequence()/bounds() for every mode.
 func (g *PathGenerator) ForEach(fn func(PathValues)) {
 	if g == nil {
 		if fn != nil {


### PR DESCRIPTION
## Summary

PR4, the closing piece of the #43 migration series (PR1: #50 Sample, PR2: #51 plain Explore, PR3: #52 Coverage/Smart). Since PR3, `runExecutionContext`'s `incrementalCapable` check covered every `ExplorationMode` value, making the `ForEach`/`[]PathValues` batch fallback beneath it dead code for any non-nil `PathGens[i]`. This PR deletes it.

## Design notes

- `runExecutionContext` now has a single two-way branch: incremental `pathSequence` path for any non-nil `PathGens[i]`, plain Describe/It path otherwise. No mode/strategy conditional left — there's nothing left to gate on.
- Updated `sequence()`/`bounds()` doc comments in `path_generator.go`: both used to say "panics if g uses a mode not yet supported." Now they say the panic is a defensive guard against an invalid `ExplorationMode` enum value, not a real gap — accurate, since all three mode values are covered.
- Updated `ForEach()`'s doc comment to note it's now purely the direct-call compatibility API (`explore_mode_selection_test.go` and similar callers) — `runExecutionContext` never calls it.
- Checked `runExploration()`/`runGuidedExploration()`'s doc comments (updated during PR3) — already accurate, no changes needed.
- Checked `execution_plan_test.go`/`path_generator_test.go` for anything tied to the removed branch — nothing; the cancellation tests exercise `runExecutionContext` generically per mode/strategy and are unaffected. The one comment referencing "the old ForEach-into-slice materialization" in `execution_plan_test.go` documents *why* that test exists (historical regression rationale), not a forward pointer — left as is.

## Changed files

- `specs/execution_plan.go` — deleted the dead `incrementalCapable`-gated `ForEach`/`[]PathValues` fallback branch (39 lines removed); dispatch simplified to a plain nil-check.
- `specs/path_generator.go` — doc comment updates only (`sequence()`, `bounds()`, `ForEach()`); no behavioral change.

## Validation

- `gofmt -l` — clean on both touched files
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all green (all packages)
- `go test ./specs/... -race` — clean
- `make build` / `make lint` — clean (0 issues)

## Closes

Closes #43 — `PathGenerator.ForEach` is no longer invoked by real execution; every mode/strategy now runs through the incremental `pathSequence` path, and the dead batch fallback that used to call it from `runExecutionContext` is gone. `ForEach` remains as the intentional, documented direct-call API for tests and other callers that construct a `PathGenerator` themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
