### PR TITLE
fix(specs): Mutator.Mutate no longer no-ops on bool/discrete/unranged-int

### DIFF
--- a/specs/explorer_coverage.go
+++ b/specs/explorer_coverage.go
@@ -4,12 +4,14 @@ package specs
 // seenCoverageHashes is maintained in the Coverage bitmap; when Feedback reports new edges,
 // the input is stored in the corpus. NextInput returns random input when corpus is empty,
 // otherwise a mutation of a random corpus entry via Mutator.Mutate: +1/-1/×2/÷2/bit-flip/nearby
-// for a ranged int or int64 dimension (see Mutator.MutateInt); other dimensions (bool, discrete,
-// unranged int) are left unchanged — see Mutator.Mutate's doc comment and #9's follow-up issue.
+// for a ranged int or int64 dimension (see Mutator.MutateInt); bool is negated; discrete dimensions
+// (unranged int/int64, .Values) are re-picked from their own value set — see Mutator.Mutate's doc
+// comment.
 //
 // This is a different mutation strategy from the one PathSpec.Explore(n) uses (PathGenerator's own
-// unexported mutate, which does mutate bool/discrete dimensions) — see Mutator.Mutate's doc comment
-// for why the two exist and aren't meant to be interchangeable.
+// unexported mutate, which mutates bool/discrete dimensions the same way but doesn't share this
+// type's int operators) — see Mutator.Mutate's doc comment for why the two exist and aren't meant
+// to be interchangeable.
 type CoverageExplorer struct {
 	corpus  *Corpus
 	mutator *Mutator

--- a/specs/mutation_strategy_test.go
+++ b/specs/mutation_strategy_test.go
@@ -1,28 +1,96 @@
 package specs
 
-// mutation_strategy_test.go locks in the documented divergence between the two independently-
-// reachable mutation strategies for property-based exploration (see #9, and the doc comments on
-// Mutator.Mutate and PathGenerator.mutate): Mutator.Mutate (used by PathSpec.ExploreCoverage/
-// ExploreSmart) is a no-op for a bool dimension, while PathGenerator.mutate (used by
-// PathSpec.Explore) unconditionally negates a bool dimension. With a single bool dimension, the
-// dimension pick is deterministic (there's nothing else to pick), so this needs no seeding tricks
-// to be reliable.
+// mutation_strategy_test.go locks in the documented behavior of the two independently-reachable
+// mutation strategies for property-based exploration (see #9, #41, and the doc comments on
+// Mutator.Mutate and PathGenerator.mutate): both now mutate every dimension kind (bool, discrete,
+// unranged int/int64, ranged int/int64), but via different mechanics — Mutator.Mutate (used by
+// PathSpec.ExploreCoverage/ExploreSmart) re-picks discrete values from the dimension's value set and
+// uses MutateInt's operators (+1/-1/×2/÷2/bit-flip/nearby) for ranged int/int64, while
+// PathGenerator.mutate (used by PathSpec.Explore) has its own simpler int mutation set. Both
+// unconditionally negate bool.
 
 import "testing"
 
-func TestMutationStrategies_DivergeOnBoolDimension(t *testing.T) {
+func TestMutationStrategies_AgreeOnBoolDimension(t *testing.T) {
 	// exploreIterations > 0 puts the generator in ExplorationGuided mode, which is what allocates
 	// g.rng — PathGenerator.mutate (unlike Mutator.Mutate, which carries its own rng) uses it.
 	gen := newPathGenerator([]PathVar{{Name: "flag", Values: []any{true, false}}}, nil, 0, 1, true, 1, 0, 0)
 	input := gen.PathValuesWith(map[string]any{"flag": true})
 
 	out := NewMutator(1).Mutate(gen, input)
-	if out.values[0] != true {
-		t.Errorf("Mutator.Mutate: expected the bool dimension to stay unchanged (documented no-op for non-int dimensions), got %v", out.values[0])
+	if out.values[0] != false {
+		t.Errorf("Mutator.Mutate: expected the bool dimension to be negated to false, got %v", out.values[0])
 	}
 
 	genMutated := gen.mutate(input)
 	if genMutated.values[0] != false {
 		t.Errorf("PathGenerator.mutate: expected the bool dimension to be negated to false, got %v", genMutated.values[0])
+	}
+}
+
+// TestMutatorMutate_DiscreteDimension_CanChangeValue guards against #41's regression: before the
+// fix, Mutator.Mutate left any non-int, non-bool dimension (and any unranged int/int64 dimension)
+// completely unchanged. With a single discrete dimension holding several values, the dimension pick
+// is deterministic, so across enough seeds the value must diverge from the input at least once.
+func TestMutatorMutate_DiscreteDimension_CanChangeValue(t *testing.T) {
+	gen := newPathGenerator([]PathVar{{Name: "color", Values: []any{"red", "green", "blue", "yellow"}}}, nil, 0, 1, true, 1, 0, 0)
+	input := gen.PathValuesWith(map[string]any{"color": "red"})
+
+	changed := false
+	for seed := int64(1); seed <= 50 && !changed; seed++ {
+		out := NewMutator(seed).Mutate(gen, input)
+		if out.values[0] != "red" {
+			changed = true
+		}
+	}
+	if !changed {
+		t.Fatal("Mutator.Mutate: expected the discrete dimension to change value across 50 seeds, stayed \"red\" every time")
+	}
+}
+
+// TestMutatorMutate_UnrangedIntDimension_CanChangeValue mirrors the discrete-dimension case for an
+// int dimension registered via .Int (explicit values, no range) instead of .IntRange — #41 also
+// covered this case, since MutateInt/DimensionBounds only apply when hasRange is true.
+func TestMutatorMutate_UnrangedIntDimension_CanChangeValue(t *testing.T) {
+	gen := newPathGenerator([]PathVar{{Name: "n", Values: []any{1, 2, 3, 4}}}, nil, 0, 1, true, 1, 0, 0)
+	input := gen.PathValuesWith(map[string]any{"n": 1})
+
+	changed := false
+	for seed := int64(1); seed <= 50 && !changed; seed++ {
+		out := NewMutator(seed).Mutate(gen, input)
+		if out.values[0] != 1 {
+			changed = true
+		}
+	}
+	if !changed {
+		t.Fatal("Mutator.Mutate: expected the unranged int dimension to change value across 50 seeds, stayed 1 every time")
+	}
+}
+
+func TestPathGeneratorDimensionValues(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "color", Values: []any{"red", "green", "blue"}},
+		{Name: "n", rangeSpec: &intRange{min: 0, max: 9}},
+	}, nil, 0, 0, false, 0, 0, 0)
+
+	discrete := gen.DimensionValues(0)
+	if len(discrete) != 3 || discrete[0] != "red" || discrete[1] != "green" || discrete[2] != "blue" {
+		t.Fatalf("DimensionValues(0) = %v, want [red green blue]", discrete)
+	}
+
+	if ranged := gen.DimensionValues(1); ranged != nil {
+		t.Fatalf("DimensionValues(1) = %v, want nil for a ranged dimension", ranged)
+	}
+
+	if out := gen.DimensionValues(-1); out != nil {
+		t.Fatalf("DimensionValues(-1) = %v, want nil for an out-of-range index", out)
+	}
+	if out := gen.DimensionValues(2); out != nil {
+		t.Fatalf("DimensionValues(2) = %v, want nil for an out-of-range index", out)
+	}
+
+	discrete[0] = "mutated"
+	if gen.DimensionValues(0)[0] != "red" {
+		t.Fatal("DimensionValues: returned slice must be a copy, mutating it corrupted generator state")
 	}
 }

--- a/specs/mutator.go
+++ b/specs/mutator.go
@@ -61,17 +61,16 @@ func (m *Mutator) MutateInt(v, min, max int) int {
 
 // Mutate returns a clone of p with one random dimension mutated.
 // For int/int64 dimensions with a range, MutateInt is used and the result is clamped to generator
-// bounds. Other dimensions (bool, discrete values, unranged int/int64) are left unchanged — this
-// call can be a no-op if the randomly picked dimension isn't a ranged int/int64. See #9's follow-up
-// issue for tracking that gap.
+// bounds. bool dimensions are always negated (guaranteed to change). Discrete dimensions (unranged
+// int/int64, or .Values) are re-picked from the dimension's own value set via DimensionValues —
+// same as PathGenerator.mutate's discrete case, this may coincidentally land back on the same value.
 //
 // This is the mutation strategy behind PathSpec.ExploreCoverage/ExploreSmart (via CoverageExplorer/
 // SmartExplorer). PathSpec.Explore uses a different, unexported strategy (PathGenerator.mutate in
-// path_generator.go) that has an explicit mutation path for bool and discrete dimensions too (bool
-// is always flipped; a discrete re-pick may coincidentally land on the same value), at the cost of
-// not sharing this type's int-mutation operators (bit-flip, ×2/÷2, etc. — see MutateInt). The two
-// aren't meant to be interchangeable: each backs a distinct public exploration mode, evolved
-// independently rather than consolidated, per the discussion on #9.
+// path_generator.go) that mutates bool/discrete dimensions the same way, at the cost of not sharing
+// this type's int-mutation operators (bit-flip, ×2/÷2, etc. — see MutateInt). The two aren't meant
+// to be interchangeable: each backs a distinct public exploration mode, evolved independently rather
+// than consolidated, per the discussion on #9.
 func (m *Mutator) Mutate(gen *PathGenerator, p PathValues) PathValues {
 	if m == nil || m.rng == nil || gen == nil {
 		return p.clone()
@@ -90,23 +89,29 @@ func (m *Mutator) Mutate(gen *PathGenerator, p PathValues) PathValues {
 	min, max, hasRange := gen.DimensionBounds(dim)
 
 	switch v := val.(type) {
+	case bool:
+		out.values[idx] = !v
+		out.present[idx] = true
 	case int:
 		if hasRange {
 			out.values[idx] = m.MutateInt(v, min, max)
-		} else {
-			out.values[idx] = v
+		} else if values := gen.DimensionValues(dim); len(values) > 0 {
+			out.values[idx] = values[m.rng.Intn(len(values))]
 		}
 		out.present[idx] = true
 	case int64:
 		if hasRange {
 			mi, ma := int(min), int(max)
 			out.values[idx] = int64(m.MutateInt(int(v), mi, ma))
-		} else {
-			out.values[idx] = v
+		} else if values := gen.DimensionValues(dim); len(values) > 0 {
+			out.values[idx] = values[m.rng.Intn(len(values))]
 		}
 		out.present[idx] = true
 	default:
-		// discrete or non-int: leave unchanged (no bounds to clamp to)
+		if values := gen.DimensionValues(dim); len(values) > 0 {
+			out.values[idx] = values[m.rng.Intn(len(values))]
+		}
+		out.present[idx] = true
 	}
 	return out
 }

--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -950,6 +950,22 @@ func (g *PathGenerator) DimensionBounds(dim int) (min, max int, hasRange bool) {
 	return d.rangeMin, d.rangeMax, true
 }
 
+// DimensionValues returns a copy of dimension dim's discrete value set, for dimensions that don't
+// have an int range (DimensionBounds's hasRange false) — e.g. .Bool, .Int(name, []int{...}), or
+// .Values. Returns nil if dim is out of range or the dimension uses an int range instead.
+func (g *PathGenerator) DimensionValues(dim int) []any {
+	if g == nil || dim < 0 || dim >= len(g.dims) {
+		return nil
+	}
+	d := g.dims[dim]
+	if d.hasRange {
+		return nil
+	}
+	out := make([]any, len(d.values))
+	copy(out, d.values)
+	return out
+}
+
 // ForEachShrinkCandidate calls fn for each candidate PathValues with dimension dimIdx
 // shrunk via the dimension's value shrinker. Only candidates that pass the generator's
 // filters are passed to fn. If fn returns false, iteration stops. pv is not modified.


### PR DESCRIPTION
## Summary

Fixes #41. `Mutator.Mutate` — the strategy behind `PathSpec.ExploreCoverage`/`ExploreSmart` — silently no-oped whenever the randomly-picked dimension was bool, discrete (`.Values`), or an unranged int/int64 (`.Int(name, []int{...})`). Only ranged int/int64 dimensions actually mutated, via `MutateInt`/`DimensionBounds`. `PathGenerator.mutate` (the `.Explore` strategy) never had this gap.

## Design notes

- Added `PathGenerator.DimensionValues(dim int) []any` — mirrors `DimensionBounds`, but for the discrete side: returns a defensive copy of the dimension's value set when it doesn't have an int range, `nil` otherwise (out-of-range index or ranged dimension). A copy, not the internal slice, so a caller can't corrupt generator state — covered by `TestPathGeneratorDimensionValues`.
- `Mutator.Mutate` now has an explicit `bool` case: unconditional negation, matching `PathGenerator.mutate`'s guaranteed-change behavior for bool.
- `int`/`int64` dimensions without a range, and any other discrete type (the `default` case — strings, etc. via `.Values`), now re-pick from `DimensionValues(dim)` using the mutator's own `rng`. Same as `PathGenerator.mutate`'s discrete case, this can coincidentally land back on the same value — it's a real mutation path now, not a guaranteed change like bool.
- Ranged int/int64 mutation (`MutateInt`: +1/-1/×2/÷2/bit-flip/nearby) is untouched.
- The two mutation strategies (`Mutator.Mutate` vs `PathGenerator.mutate`) still aren't consolidated — per #9, they back distinct exploration modes and evolved independently. This PR closes the *no-op* gap in `Mutator.Mutate`, not the pre-existing divergence in *how* each mutates ranged ints.
- Updated `explorer_coverage.go`'s doc comment, which described the old no-op behavior as `CoverageExplorer`'s documented tradeoff — now accurate.

## Changed files

- `specs/mutator.go` — `Mutate` gains a `bool` case and a `DimensionValues`-backed re-pick for discrete/unranged-int; doc comment updated.
- `specs/path_generator.go` — new `DimensionValues` accessor.
- `specs/explorer_coverage.go` — doc comment updated to match the fixed behavior.
- `specs/mutation_strategy_test.go` — `TestMutationStrategies_DivergeOnBoolDimension` (which locked in the old no-op as intended behavior) replaced with `TestMutationStrategies_AgreeOnBoolDimension`; added `TestMutatorMutate_DiscreteDimension_CanChangeValue`, `TestMutatorMutate_UnrangedIntDimension_CanChangeValue`, and `TestPathGeneratorDimensionValues`.

## Validation

- `gofmt -l` — clean on all touched files
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all green (all packages)
- `go test ./specs/... -race` — clean
- `make build` / `make lint` — clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
