### PR TITLE
fix(specs): RunParallel/RunParallelBatched abort a spec after a fatal assertion

### DIFF
--- a/specs/minimal_runner.go
+++ b/specs/minimal_runner.go
@@ -111,6 +111,7 @@ func (r *MinimalRunner) RunParallel(tb failureReporter, workers int) {
 	for i := range backends {
 		backends[i].results = &results
 		backends[i].specIndex = -1
+		backends[i].abortOnFatal = true
 	}
 
 	var next uint32
@@ -157,6 +158,7 @@ func (r *MinimalRunner) RunParallelBatched(tb failureReporter, workers int, chun
 	for i := range backends {
 		backends[i].results = &results
 		backends[i].specIndex = -1
+		backends[i].abortOnFatal = true
 	}
 
 	var next uint32

--- a/specs/scheduler.go
+++ b/specs/scheduler.go
@@ -25,9 +25,8 @@ type parallelBackend struct {
 	results   *[]string
 	// abortOnFatal, when true, makes FailNow/Fatal/Fatalf panic(parallelAbort{}) after recording,
 	// so a fatal assertion stops the rest of the spec body — matching testing.T.FailNow's abort
-	// semantics. RunParallel's worker pool (runWorker/runWorkerBatched) leaves this false: a fatal
-	// assertion there records the failure but does not stop the spec (existing behavior, tracked
-	// separately). parallelStep (ItParallel, program.go) sets it true.
+	// semantics. Both parallelStep (ItParallel, program.go) and RunParallel's worker pool
+	// (runWorker/runWorkerBatched, via MinimalRunner.RunParallel/RunParallelBatched) set this true.
 	abortOnFatal bool
 }
 
@@ -106,9 +105,28 @@ func runWorker(specs []RunSpec, backend *parallelBackend, next *uint32, results 
 		backend.specIndex = idx
 		ctx.Reset(backend)
 		ctx.SetPathValues(PathValues{})
-		specs[idx].Fn(ctx)
+		runWorkerSpec(specs[idx].Fn, ctx, results, idx)
 		ctx.Reset(nil)
 	}
+}
+
+// runWorkerSpec runs one spec body, recovering the parallelAbort{} sentinel a fatal assertion
+// panics with when backend.abortOnFatal is set (see parallelBackend.FailNow/Fatal/Fatalf) — an
+// expected stop, already recorded in results[idx], not a failure to report. Any other panic is
+// recorded as an ordinary spec failure instead of crashing the worker goroutine. Mirrors
+// parallelStep's per-spec recover in program.go, applied per spec here too so one spec's fatal
+// assertion or panic doesn't stop the worker from running the rest of its specs.
+func runWorkerSpec(fn func(*Context), ctx *Context, results *[]string, idx int) {
+	defer func() {
+		switch r := recover(); r {
+		case nil, parallelAbort{}:
+		default:
+			if (*results)[idx] == "" {
+				(*results)[idx] = fmt.Sprintf("panic: %v", r)
+			}
+		}
+	}()
+	fn(ctx)
 }
 
 // failureReporter is the minimal interface needed to report failures (avoids requiring full testing.TB in tests).

--- a/specs/scheduler_batch.go
+++ b/specs/scheduler_batch.go
@@ -16,7 +16,9 @@ const DefaultChunkSize = 16
 
 // runWorkerBatched runs specs in chunks. Each iteration claims [start, end) via
 // atomic.AddUint32(next, chunkSize); then runs specs[start:end] with one context Reset per chunk
-// (not per spec), reducing backend setup overhead. No allocations in the loop.
+// (not per spec), reducing backend setup overhead. A fatal assertion aborts only the spec that
+// raised it (see runWorkerSpec) — the chunk loop continues to the next spec. No allocations in
+// the loop.
 func runWorkerBatched(specs []RunSpec, backend *parallelBackend, next *uint32, results *[]string, chunkSize uint32) {
 	ctx := contextPool.Get().(*Context)
 	defer func() {
@@ -43,7 +45,7 @@ func runWorkerBatched(specs []RunSpec, backend *parallelBackend, next *uint32, r
 		for i := start; i < end; i++ {
 			idx := int(i)
 			backend.specIndex = idx
-			specs[idx].Fn(ctx)
+			runWorkerSpec(specs[idx].Fn, ctx, results, idx)
 		}
 		ctx.Reset(nil)
 	}

--- a/specs/scheduler_test.go
+++ b/specs/scheduler_test.go
@@ -73,6 +73,79 @@ func TestRunParallelBatched_DeterministicReport(t *testing.T) {
 	}
 }
 
+// TestRunParallel_FatalAssertionStopsSpecBody verifies a fatal assertion (EqualTo failing, which
+// calls parallelBackend.Fatalf) stops the rest of that spec's body — same as a sequential It, and
+// same as ItParallel since #24. Before #38's fix, RunParallel's worker pool left abortOnFatal
+// false, so Fatalf recorded the failure but returned normally and code after it kept running.
+func TestRunParallel_FatalAssertionStopsSpecBody(t *testing.T) {
+	r := NewMinimalRunner(1)
+	var ranAfterFailure bool
+	r.Add("s0", func(ctx *Context) {
+		EqualTo(ctx, 1, 2)
+		ranAfterFailure = true // must not run: the assertion above is fatal
+	})
+
+	var reported string
+	fake := &fakeReporter{fatalf: func(format string, args ...any) { reported = fmt.Sprintf(format, args...) }}
+	r.RunParallel(fake, 1)
+
+	if reported == "" {
+		t.Fatal("expected a failure to be reported")
+	}
+	if !strings.Contains(reported, "expected 1 to equal 2") {
+		t.Errorf("expected the assertion failure message, got %q", reported)
+	}
+	if ranAfterFailure {
+		t.Error("expected code after the fatal assertion to be skipped, but it ran")
+	}
+}
+
+// TestRunParallel_FatalAssertionDoesNotStopOtherSpecs verifies a spec's fatal assertion aborts only
+// that spec, not the worker running it — the worker must still run the specs after it. Uses a
+// single worker so spec order relative to the failing one is deterministic.
+func TestRunParallel_FatalAssertionDoesNotStopOtherSpecs(t *testing.T) {
+	r := NewMinimalRunner(3)
+	var laterRan int32
+	r.Add("s0", func(ctx *Context) { EqualTo(ctx, 1, 2) }) // fails, aborts
+	r.Add("s1", func(ctx *Context) { atomic.AddInt32(&laterRan, 1); EqualTo(ctx, 1, 1) })
+	r.Add("s2", func(ctx *Context) { atomic.AddInt32(&laterRan, 1); EqualTo(ctx, 1, 1) })
+
+	fake := &fakeReporter{fatalf: func(string, ...any) {}}
+	r.RunParallel(fake, 1)
+
+	if laterRan != 2 {
+		t.Errorf("expected the 2 specs after the failing one to still run, got %d", laterRan)
+	}
+}
+
+// TestRunParallelBatched_FatalAssertionStopsSpecBody mirrors
+// TestRunParallel_FatalAssertionStopsSpecBody for the batched worker loop (runWorkerBatched),
+// including that the chunk loop continues to the next spec in the same chunk after an abort.
+func TestRunParallelBatched_FatalAssertionStopsSpecBody(t *testing.T) {
+	r := NewMinimalRunner(4)
+	var ranAfterFailure bool
+	var laterRan int32
+	r.Add("s0", func(ctx *Context) {
+		EqualTo(ctx, 1, 2)
+		ranAfterFailure = true // must not run: the assertion above is fatal
+	})
+	r.Add("s1", func(ctx *Context) { atomic.AddInt32(&laterRan, 1); EqualTo(ctx, 1, 1) })
+
+	var reported string
+	fake := &fakeReporter{fatalf: func(format string, args ...any) { reported = fmt.Sprintf(format, args...) }}
+	r.RunParallelBatched(fake, 1, 4) // 1 worker, chunkSize 4 so both specs land in the same chunk
+
+	if reported == "" {
+		t.Fatal("expected a failure to be reported")
+	}
+	if ranAfterFailure {
+		t.Error("expected code after the fatal assertion to be skipped, but it ran")
+	}
+	if laterRan != 1 {
+		t.Errorf("expected the spec after the failing one in the same chunk to still run, got %d", laterRan)
+	}
+}
+
 // fakeReporter implements failureReporter for tests (captures Fatalf instead of failing).
 type fakeReporter struct {
 	fatalf func(string, ...any)
@@ -84,4 +157,3 @@ func (f *fakeReporter) Fatalf(format string, args ...any) {
 		f.fatalf(format, args...)
 	}
 }
-


### PR DESCRIPTION
## Summary

Fixes #38. Same root cause as #24, one scope-level up: `parallelBackend.Fatal/Fatalf/FailNow` recorded a failure into `results[specIndex]` but returned normally, instead of stopping execution like `testing.T.FailNow`'s `runtime.Goexit`. #24 fixed this for `ItParallel` (`parallelStep` in `program.go`) by adding `abortOnFatal` + a `parallelAbort{}` panic sentinel, but deliberately left `abortOnFatal: false` for `RunParallel`'s worker pool to keep that PR scoped. This PR wires the same mechanism into `RunParallel`/`RunParallelBatched`.

## Design notes

- `MinimalRunner.RunParallel`/`RunParallelBatched` (`minimal_runner.go`) now set `abortOnFatal: true` on every `parallelBackend` they construct — the sentinel type and the flag itself already existed in `scheduler.go` from #24, this is just wiring them up on the `RunParallel` side.
- New `runWorkerSpec(fn, ctx, results, idx)` helper in `scheduler.go`, shared by both `runWorker` and `runWorkerBatched`: runs one spec body, recovers `parallelAbort{}` as an expected, already-recorded stop, and records any other panic as an ordinary spec failure — mirroring `parallelStep`'s per-spec recover in `program.go`. Applied **per spec**, not per worker/chunk, so one spec's fatal assertion (or panic) doesn't stop the worker from running the rest of its specs — `runWorkerBatched`'s chunk loop in particular continues to the next spec in the same chunk after an abort.
- Updated the now-stale `abortOnFatal` doc comment on `parallelBackend` (previously documented `RunParallel` as leaving it `false`) and `runWorkerBatched`'s doc comment to note the per-spec abort scope.

## Changed files

- `specs/scheduler.go` — `runWorker` delegates to new `runWorkerSpec`; doc comment on `abortOnFatal` updated.
- `specs/scheduler_batch.go` — `runWorkerBatched`'s chunk loop delegates to `runWorkerSpec`; doc comment updated.
- `specs/minimal_runner.go` — `abortOnFatal: true` set in both `RunParallel` and `RunParallelBatched`'s backend construction loops.
- `specs/scheduler_test.go` — `TestRunParallel_FatalAssertionStopsSpecBody` (mirrors #24's `TestParallelStep_FatalAssertionStopsSpecBody`), `TestRunParallel_FatalAssertionDoesNotStopOtherSpecs` (proves the abort is per-spec, not per-worker), `TestRunParallelBatched_FatalAssertionStopsSpecBody` (same, for the batched chunk loop, proving the chunk continues past the aborted spec).

## Validation

- `gofmt -l` — clean on all touched files
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all green (all packages)
- `go test ./specs/... -race -count=2` — clean
- `make build` / `make lint` — clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
