### PR TITLE
fix(specs): parallelBackend.Run fails loudly instead of silently no-op

### DIFF
--- a/specs/scheduler.go
+++ b/specs/scheduler.go
@@ -80,9 +80,14 @@ func (p *parallelBackend) Name() string { return "" }
 
 func (p *parallelBackend) Cleanup(func()) {}
 
+// Run reports subtests as unsupported instead of silently skipping them. Parallel mode (ItParallel,
+// RunParallel, RunParallelBatched) has no mechanism to run a subtest body against a live testing.TB
+// from a worker goroutine, so fn is never called; unlike the old no-op, that is now a fatal failure
+// on this spec (via Fatalf, so it also aborts the rest of the spec body when abortOnFatal is set —
+// always true for every parallelBackend constructed in this package) instead of vanishing silently.
+// Specs that need t.Run should use the sequential runner (MinimalRunner.Run).
 func (p *parallelBackend) Run(name string, fn func(testing.TB)) {
-	// Parallel mode does not support subtests; Run is a no-op so the spec does not block.
-	// Specs that need t.Run should use the sequential runner.
+	p.Fatalf("t.Run(%q, ...) is not supported in parallel mode (ItParallel/RunParallel/RunParallelBatched); the subtest was not run — use the sequential runner for specs that need t.Run", name)
 }
 
 // runWorker runs specs whose indexes it acquires via next. Uses one Context from the pool for

--- a/specs/scheduler_test.go
+++ b/specs/scheduler_test.go
@@ -146,6 +146,56 @@ func TestRunParallelBatched_FatalAssertionStopsSpecBody(t *testing.T) {
 	}
 }
 
+// TestParallelBackend_RunFailsLoudlyInsteadOfNoOp verifies #28's fix: t.Run under parallel mode
+// used to silently no-op (fn never called, no failure recorded, no signal at all). It now records
+// a fatal failure on the calling spec via Fatalf (fn still never called — parallel mode genuinely
+// has no mechanism to run a subtest against a live testing.TB from a worker goroutine) instead of
+// vanishing without a trace.
+func TestParallelBackend_RunFailsLoudlyInsteadOfNoOp(t *testing.T) {
+	results := make([]string, 1)
+	backend := &parallelBackend{specIndex: 0, results: &results}
+
+	var subtestRan bool
+	backend.Run("generated", func(testing.TB) { subtestRan = true })
+
+	if subtestRan {
+		t.Error("expected the subtest body to never run under parallel mode, but it ran")
+	}
+	if results[0] == "" {
+		t.Fatal("expected Run to record a failure, got none")
+	}
+	if !strings.Contains(results[0], "generated") {
+		t.Errorf("expected the failure to mention the subtest name, got %q", results[0])
+	}
+}
+
+// TestParallelBackend_RunAbortsSpecWhenAbortOnFatal verifies Run's failure aborts the rest of the
+// spec body when abortOnFatal is set (as it always is for every parallelBackend constructed by this
+// package — see runWorker, runWorkerBatched, and parallelStep in program.go), same as any other
+// fatal assertion.
+func TestParallelBackend_RunAbortsSpecWhenAbortOnFatal(t *testing.T) {
+	results := make([]string, 1)
+	backend := &parallelBackend{specIndex: 0, results: &results, abortOnFatal: true}
+
+	var ranAfter bool
+	func() {
+		defer func() {
+			if r := recover(); r != (parallelAbort{}) {
+				t.Errorf("expected recover to yield parallelAbort{}, got %v", r)
+			}
+		}()
+		backend.Run("generated", func(testing.TB) {})
+		ranAfter = true
+	}()
+
+	if ranAfter {
+		t.Error("expected code after Run to be skipped, but it ran")
+	}
+	if results[0] == "" {
+		t.Error("expected Run to record a failure before aborting")
+	}
+}
+
 // fakeReporter implements failureReporter for tests (captures Fatalf instead of failing).
 type fakeReporter struct {
 	fatalf func(string, ...any)


### PR DESCRIPTION
## Summary

Fixes #28. `parallelBackend.Run` (`specs/scheduler.go`) used to be a pure no-op:

```go
func (p *parallelBackend) Run(name string, fn func(testing.TB)) {
	// Parallel mode does not support subtests; Run is a no-op so the spec does not block.
	// Specs that need t.Run should use the sequential runner.
}
```

`fn` was never called and nothing was recorded anywhere — no failure, no log. A subtest under `ItParallel`/`RunParallel`/`RunParallelBatched` just vanished without a trace. This PR makes it fail loudly instead.

## Design notes

- `Run` now calls `p.Fatalf(...)` with a message naming the subtest and explaining why it can't run, reusing the exact same recording path as every other fatal assertion in `parallelBackend`. Since every `parallelBackend` this package constructs (`program.go`'s `parallelStep`, `minimal_runner.go`'s `RunParallel`/`RunParallelBatched`) sets `abortOnFatal: true`, this also aborts the rest of the spec body — same semantics as any other fatal assertion, no special-casing needed.
- Investigated whether `parallelBackend.Run` is actually reachable today: the only internal call site of `testBackend.Run` is `runIsolatedCase` (`execution_plan.go`), and it already type-switches on `*runnableBackend` before calling `.Run`, falling back to `runIsolatedCaseDirect` for any other backend (including `*parallelBackend`) — so it was never hitting the no-op. There's also no public accessor from `*Context` to the backend or to a `testing.TB` under parallel mode (`ctx.T` stays `nil`), so this was previously unreachable through any current internal or external path. Fixing it anyway per the issue: it's part of the `testBackend` interface contract, and a silent no-op there is a footgun for any future code path (or backend implementation) that calls `Run` generically without the `*runnableBackend` type-check `runIsolatedCase` happens to have today.
- `fn` still never runs — parallel mode has no mechanism to run a subtest against a live `testing.TB` from a worker goroutine. That part of the original behavior is correct and unchanged; only the "silently vanish" part is fixed.

## Changed files

- `specs/scheduler.go` — `parallelBackend.Run` now calls `Fatalf` instead of no-op; doc comment rewritten to explain why `fn` is never called and that the failure now aborts via the existing `abortOnFatal` mechanism.
- `specs/scheduler_test.go` — `TestParallelBackend_RunFailsLoudlyInsteadOfNoOp` (fn never runs, failure recorded, message names the subtest), `TestParallelBackend_RunAbortsSpecWhenAbortOnFatal` (code after `Run` is skipped, consistent with any other fatal assertion).

## Validation

- `gofmt -l` — clean on touched files
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all green (all packages)
- `go test ./specs/... -race -count=2` — clean
- `make build` / `make lint` — clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
