### PR TITLE
fix(snapshots): serialize RunFromFile's load-mutate-save cycle per file

### DIFF
--- a/snapshots/snapshot.go
+++ b/snapshots/snapshot.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"sync"
 )
 
 const UpdateSnapshotsEnv = "GO_SPECS_UPDATE_SNAPSHOTS"
@@ -14,6 +15,22 @@ const UpdateSnapshotsEnv = "GO_SPECS_UPDATE_SNAPSHOTS"
 // Backend is used to report failures (e.g. testing.TB).
 type Backend interface {
 	Fatalf(format string, args ...any)
+}
+
+// fileLocks serializes RunFromFile's load-mutate-save cycle per snapshot file, keyed by absolute
+// path. Without it, two specs sharing a snapshot file (e.g. parallel specs in the same test file,
+// each snapshotting under a different name) race: both Load the same on-disk contents, each mutates
+// its own key in its own in-memory copy, and whichever Save runs last silently clobbers the other's
+// update. The lock also protects concurrent reads from observing a partially-written file mid-Save.
+var fileLocks sync.Map // map[string]*sync.Mutex
+
+func lockFor(path string) *sync.Mutex {
+	key := path
+	if abs, err := filepath.Abs(path); err == nil {
+		key = abs
+	}
+	v, _ := fileLocks.LoadOrStore(key, &sync.Mutex{})
+	return v.(*sync.Mutex)
 }
 
 // RunFromFile compares value to the stored snapshot for name, or creates/updates it.
@@ -38,6 +55,10 @@ func RunFromFile(backend Backend, callerFile string, name string, value any) {
 		backend.Fatalf("snapshot: marshal: %v", err)
 		return
 	}
+
+	mu := lockFor(snapshotPath)
+	mu.Lock()
+	defer mu.Unlock()
 
 	update := os.Getenv(UpdateSnapshotsEnv) == "1"
 	data, err := Load(snapshotPath)

--- a/snapshots/snapshot_test.go
+++ b/snapshots/snapshot_test.go
@@ -1,0 +1,114 @@
+package snapshots
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+type fakeBackend struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (f *fakeBackend) Fatalf(format string, args ...any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.msgs = append(f.msgs, fmt.Sprintf(format, args...))
+}
+
+func (f *fakeBackend) failures() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.msgs))
+	copy(out, f.msgs)
+	return out
+}
+
+// TestRunFromFile_ConcurrentUpdatesDoNotClobberEachOther verifies #27's fix: many goroutines
+// snapshotting under distinct names into the same file, concurrently, in update mode, must not
+// lose any writes to a load-mutate-save race. Before the per-file mutex, each goroutine's Save
+// could overwrite another's just-written key because both started from the same on-disk read.
+func TestRunFromFile_ConcurrentUpdatesDoNotClobberEachOther(t *testing.T) {
+	t.Setenv(UpdateSnapshotsEnv, "1")
+	dir := t.TempDir()
+	callerFile := filepath.Join(dir, "concurrent_test.go")
+
+	const n = 50
+	backend := &fakeBackend{}
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			RunFromFile(backend, callerFile, fmt.Sprintf("key-%d", i), i)
+		}(i)
+	}
+	wg.Wait()
+
+	if msgs := backend.failures(); len(msgs) > 0 {
+		t.Fatalf("expected no failures, got: %v", msgs)
+	}
+
+	snapshotPath := filepath.Join(dir, "__snapshots__", "concurrent_test.snap.json")
+	data, err := Load(snapshotPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(data) != n {
+		t.Fatalf("expected %d keys, got %d (lost writes to a load-mutate-save race)", n, len(data))
+	}
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("key-%d", i)
+		if _, ok := data[key]; !ok {
+			t.Errorf("missing key %q", key)
+		}
+	}
+}
+
+// TestRunFromFile_ConcurrentUpdatesToSameKeyDoNotCorruptFile verifies many goroutines racing to
+// update the very same key (not just distinct keys) still leave a well-formed, readable file: the
+// per-file mutex fully serializes each Load-mutate-Save cycle, so writes interleave cleanly instead
+// of tearing mid-write.
+func TestRunFromFile_ConcurrentUpdatesToSameKeyDoNotCorruptFile(t *testing.T) {
+	t.Setenv(UpdateSnapshotsEnv, "1")
+	dir := t.TempDir()
+	callerFile := filepath.Join(dir, "samekey_test.go")
+
+	const n = 50
+	backend := &fakeBackend{}
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			RunFromFile(backend, callerFile, "shared", i)
+		}(i)
+	}
+	wg.Wait()
+
+	if msgs := backend.failures(); len(msgs) > 0 {
+		t.Fatalf("expected no failures, got: %v", msgs)
+	}
+
+	snapshotPath := filepath.Join(dir, "__snapshots__", "samekey_test.snap.json")
+	data, err := Load(snapshotPath)
+	if err != nil {
+		t.Fatalf("Load: %v (file corrupted by an unserialized write)", err)
+	}
+	if _, ok := data["shared"]; !ok {
+		t.Fatal("expected key \"shared\" to be present")
+	}
+}
+
+func TestRunFromFile_MissingKeyFails(t *testing.T) {
+	dir := t.TempDir()
+	callerFile := filepath.Join(dir, "missing_test.go")
+	backend := &fakeBackend{}
+	RunFromFile(backend, callerFile, "nonexistent", 42)
+	msgs := backend.failures()
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly one failure, got %v", msgs)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #27. `snapshots/snapshot.go`'s `RunFromFile` flow is `Load(path)` → mutate an in-memory map → `Save(path, data)`, with zero synchronization. Concurrent `ctx.Snapshot()` calls from parallel specs targeting the same snapshot file race: both goroutines `Load` the same on-disk contents, each mutates its own key in its own in-memory copy, and whichever `Save` runs last silently clobbers the other's update — worse, two `Save`s can interleave mid-write and leave a genuinely corrupted (unparseable) file.

## Design notes

- New package-level `fileLocks sync.Map` mapping absolute snapshot path → `*sync.Mutex`. `lockFor(path)` resolves the path to absolute (so relative/absolute callers of the same file share a lock) and does a `LoadOrStore` to get/create the mutex for that path.
- `RunFromFile` now holds that mutex for its entire `Load` → mutate → `Save` critical section (`mu.Lock(); defer mu.Unlock()` right after computing `snapshotPath` and marshaling the new value, before the first `Load`). This serializes **reads against writes too**, not just writes against writes — a non-update-mode comparison read can no longer observe a half-written file from a concurrent update-mode `Save`.
- Kept the lock scope to `RunFromFile` only; `Load`/`Save` themselves stay unsynchronized primitives (matches their existing public API — they're the building blocks, `RunFromFile` is the safe orchestration entry point real spec code goes through via `ctx.Snapshot()`).
- Reached `ctx.Snapshot()` → `runSnapshot` (`specs/snapshot.go`) → `snapshots.RunFromFile` — this is directly callable from parallel spec bodies (`ItParallel`, `RunParallel`/`RunParallelBatched`), so the race is real and reachable through the public API, not just a theoretical concern.

## Changed files

- `snapshots/snapshot.go` — added `fileLocks`/`lockFor`, `RunFromFile` now locks around its load-mutate-save section.
- `snapshots/snapshot_test.go` — new file (package had no tests before):
  - `TestRunFromFile_ConcurrentUpdatesDoNotClobberEachOther` — 50 goroutines, distinct keys, same file, update mode; asserts all 50 keys survive. Verified this fails without the fix (reverted just the `snapshot.go` change locally and reran — got `FAIL`s with `parse snapshot file: unexpected end of JSON input` / `invalid character '}' after top-level value`, i.e. genuinely corrupted/truncated files from interleaved writes, not just lost keys).
  - `TestRunFromFile_ConcurrentUpdatesToSameKeyDoNotCorruptFile` — 50 goroutines racing to update the *same* key; asserts the resulting file is still valid/readable.
  - `TestRunFromFile_MissingKeyFails` — baseline coverage for the existing missing-key-fails path (was untested before).

## Validation

- `gofmt -l` — clean on touched files
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all green (all packages)
- `go test ./... -race -count=2` — clean
- `make build` / `make lint` — clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
