### PR TITLE
fix(mock): guard Mock.spies with a mutex

### DIFF
--- a/mock/concurrency_test.go
+++ b/mock/concurrency_test.go
@@ -20,6 +20,56 @@ func TestMockCallConcurrentInvocations(t *testing.T) {
 	spy.CalledTimes(t, 50)
 }
 
+// TestMockSpyConcurrentFirstCallSameName verifies #26's fix: many goroutines racing to create the
+// spy for the SAME name for the first time (the lazy-write path in Mock.Spy) must not race on the
+// underlying map and must all observe the same *Spy instance — calls made through different
+// goroutines' returned pointers must all land on it, not be silently lost to separate spies.
+func TestMockSpyConcurrentFirstCallSameName(t *testing.T) {
+	m := New()
+	const n = 100
+	spies := make([]*Spy, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			spies[i] = m.Spy("shared")
+		}(i)
+	}
+	wg.Wait()
+
+	first := spies[0]
+	for i, s := range spies {
+		if s != first {
+			t.Fatalf("spy[%d] = %p, want the same instance as spy[0] = %p", i, s, first)
+		}
+	}
+	first.Call("x")
+	first.CalledTimes(t, 1)
+}
+
+// TestMockSpyConcurrentFirstCallDistinctNames verifies concurrent first-time Spy(name) calls for
+// distinct names don't race on the map and every name ends up with its own spy.
+func TestMockSpyConcurrentFirstCallDistinctNames(t *testing.T) {
+	m := New()
+	const n = 100
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			m.Spy(string(rune('a' + i%26))).Call(i)
+		}(i)
+	}
+	wg.Wait()
+
+	for c := 'a'; c < 'a'+26; c++ {
+		if s := m.Spy(string(c)); len(s.Calls()) == 0 {
+			t.Errorf("expected spy %q to have recorded at least one call", string(c))
+		}
+	}
+}
+
 func TestSpyConcurrentInvocations(t *testing.T) {
 	spy := NewSpy()
 	var wg sync.WaitGroup

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,7 +1,12 @@
 package mock
 
-// Mock holds named spies for verification.
+import "sync"
+
+// Mock holds named spies for verification. Safe for concurrent use, matching Spy's own guarantee —
+// e.g. specs run via RunParallel/ItParallel can call Spy(name) concurrently, including the first
+// call for a given name (which lazily creates the entry).
 type Mock struct {
+	mu    sync.Mutex
 	spies map[string]*Spy
 }
 
@@ -17,6 +22,8 @@ func (m *Mock) Spy(name string) *Spy {
 	if m == nil {
 		return nil
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if s, ok := m.spies[name]; ok {
 		return s
 	}


### PR DESCRIPTION
## Summary

Fixes #26. `mock.Mock.Spy(name)` reads `m.spies[name]` and, if absent, creates and stores a new `*Spy` — with no synchronization. `Spy` itself already documents "safe for concurrent use" and backs that with its own `sync.Mutex`, but `Mock`'s map around it had none. Concurrent calls to `Spy(name)` (e.g. from parallel specs via `ItParallel`/`RunParallel`) race on the underlying `map[string]*Spy`:

- Two goroutines racing on the *first* call for the same name can each build a separate `*Spy` and both write it into the map — whichever write loses silently drops the other's calls, since callers keep whatever pointer their own call returned.
- Concurrent reads/writes to a plain Go map from multiple goroutines are a data race regardless of outcome (can also panic with "concurrent map read and map write" or corrupt the map).

## Design notes

- Added a `sync.Mutex` field to `Mock`, held for the whole `Spy` method body (read + lazy-create), matching `Spy`'s own style in the same package rather than introducing a different primitive (e.g. `RWMutex`/`sync.Map`) for a method this cheap.

## Changed files

- `mock/mock.go` — `Mock` gains `mu sync.Mutex`; `Spy(name)` locks around the read+create.
- `mock/concurrency_test.go` — added two tests targeting the previously-uncovered lazy-create race:
  - `TestMockSpyConcurrentFirstCallSameName` — 100 goroutines racing to create the spy for the *same* name for the first time; asserts they all observe the same `*Spy` instance and that calls made through it are all recorded.
  - `TestMockSpyConcurrentFirstCallDistinctNames` — 100 goroutines racing to create spies for distinct names concurrently; asserts no name's spy is lost or corrupted.

## Validation

- `gofmt -l` — clean on touched files
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all green (all packages)
- `go test ./mock/... -race -count=5` — clean
- `make build` / `make lint` — clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
