### PR TITLE
fix(specs): goroutine-scope compiler/registry to stop cross-suite corruption

### DIFF
--- a/specs/compiler.go
+++ b/specs/compiler.go
@@ -8,11 +8,11 @@ import (
 // bytecodeCompiler emits instructions directly into an ExecutionPlan during Describe.
 // No NodeArena is allocated; BeforeEach/AfterEach/It append instructions immediately.
 type bytecodeCompiler struct {
-	plan       *ExecutionPlan
-	nameStack  []string
+	plan        *ExecutionPlan
+	nameStack   []string
 	beforeStack [][]func(*Context)
 	afterStack  [][]func(*Context)
-	pathGen    *PathGenerator
+	pathGen     *PathGenerator
 	// scratch for flattening hooks and building program
 	beforeFlat []func(*Context)
 	afterFlat  []func(*Context)
@@ -161,33 +161,4 @@ func (c *bytecodeCompiler) TakePlan() *ExecutionPlan {
 	plan := c.plan
 	c.reset()
 	return plan
-}
-
-// currentCompiler returns the active bytecode compiler, or nil if not in compiler mode.
-var activeCompiler struct {
-	mu    sync.Mutex
-	stack []*bytecodeCompiler
-}
-
-func currentCompiler() *bytecodeCompiler {
-	activeCompiler.mu.Lock()
-	defer activeCompiler.mu.Unlock()
-	if len(activeCompiler.stack) == 0 {
-		return nil
-	}
-	return activeCompiler.stack[len(activeCompiler.stack)-1]
-}
-
-func pushCompiler(c *bytecodeCompiler) {
-	activeCompiler.mu.Lock()
-	activeCompiler.stack = append(activeCompiler.stack, c)
-	activeCompiler.mu.Unlock()
-}
-
-func popCompiler() {
-	activeCompiler.mu.Lock()
-	if len(activeCompiler.stack) > 0 {
-		activeCompiler.stack = activeCompiler.stack[:len(activeCompiler.stack)-1]
-	}
-	activeCompiler.mu.Unlock()
 }

--- a/specs/registry.go
+++ b/specs/registry.go
@@ -1,9 +1,11 @@
 package specs
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -41,13 +43,40 @@ type registry struct {
 	stack []int
 }
 
+// registryStack holds one Analyze/Describe registry stack per goroutine. A flat, ungoroutine-scoped
+// stack would let two goroutines building unrelated suites concurrently (e.g. two t.Parallel() tests
+// each calling Analyze or top-level Describe) observe and mutate each other's top-of-stack registry —
+// mutex-protected against low-level data races, but still logically wrong, since "current registry"
+// is meant to track a single call chain, not whichever goroutine pushed most recently process-wide.
 type registryStack struct {
-	mu    sync.Mutex
-	stack []*registry
+	mu     sync.Mutex
+	stacks map[int64][]*registry
 }
 
-var activeRegistries registryStack
-var analyzeLock sync.Mutex
+var activeRegistries = registryStack{stacks: map[int64][]*registry{}}
+
+// goroutineID extracts the numeric goroutine id from runtime.Stack's leading "goroutine N [state]:"
+// line. Used only at Analyze/Describe/BuildSuite entry points to key the per-goroutine registry
+// stack — never in the hot per-spec execution path — so its cost is one Analyze/Describe call, not
+// one per It/BeforeEach/AfterEach.
+func goroutineID() int64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	b := buf[:n]
+	const prefix = "goroutine "
+	if !bytes.HasPrefix(b, []byte(prefix)) {
+		return 0
+	}
+	b = b[len(prefix):]
+	if i := bytes.IndexByte(b, ' '); i >= 0 {
+		b = b[:i]
+	}
+	id, err := strconv.ParseInt(string(b), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}
 
 // initialArenaCap pre-sizes arena slices to avoid reallocations in large suites (e.g. 2000 specs).
 const initialArenaCap = 4096
@@ -129,25 +158,32 @@ func (r *registry) setPathGen(gen *PathGenerator) {
 }
 
 func pushRegistry(r *registry) func() {
+	gid := goroutineID()
 	activeRegistries.mu.Lock()
-	activeRegistries.stack = append(activeRegistries.stack, r)
+	activeRegistries.stacks[gid] = append(activeRegistries.stacks[gid], r)
 	activeRegistries.mu.Unlock()
 	return func() {
 		activeRegistries.mu.Lock()
-		if len(activeRegistries.stack) > 0 {
-			activeRegistries.stack = activeRegistries.stack[:len(activeRegistries.stack)-1]
+		if s := activeRegistries.stacks[gid]; len(s) > 0 {
+			if len(s) == 1 {
+				delete(activeRegistries.stacks, gid)
+			} else {
+				activeRegistries.stacks[gid] = s[:len(s)-1]
+			}
 		}
 		activeRegistries.mu.Unlock()
 	}
 }
 
 func currentRegistry() *registry {
+	gid := goroutineID()
 	activeRegistries.mu.Lock()
 	defer activeRegistries.mu.Unlock()
-	if len(activeRegistries.stack) == 0 {
+	s := activeRegistries.stacks[gid]
+	if len(s) == 0 {
 		return nil
 	}
-	return activeRegistries.stack[len(activeRegistries.stack)-1]
+	return s[len(s)-1]
 }
 
 // ensureRegistry pushes a new registry if none is active; call the returned func to pop.
@@ -195,15 +231,17 @@ func SetPathGen(gen *PathGenerator) {
 	}
 }
 
+// Analyze builds a suite tree by running fn with a fresh registry pushed for the calling goroutine.
+// Safe to call concurrently from multiple goroutines (e.g. from several t.Parallel() tests): each
+// call gets its own registry, scoped to the goroutine that called Analyze, so concurrent calls never
+// observe each other's tree.
 func Analyze(fn func()) *SuiteTree {
-	analyzeLock.Lock()
-	defer analyzeLock.Unlock()
 	reg := newRegistry()
 	pop := pushRegistry(reg)
+	defer pop()
 	if fn != nil {
 		fn()
 	}
-	pop()
 	return reg.currentSuite()
 }
 

--- a/specs/spec.go
+++ b/specs/spec.go
@@ -17,6 +17,15 @@ type Spec struct {
 	seed     int64
 	hasSeed  bool
 
+	// compiler/registry are the exact build target this Spec (and any Spec it constructs for a
+	// nested Describe/When) writes into. Set once by the top-level entry point (Describe,
+	// BuildSuite, ...) and threaded explicitly through every nested call from then on, instead of
+	// resolved via package-level global state — two goroutines building unrelated suites concurrently
+	// (e.g. two t.Parallel() tests each calling Describe) must never observe each other's compiler or
+	// registry. At most one of the two is non-nil for a given Spec.
+	compiler *bytecodeCompiler
+	registry *registry
+
 	// Either (arena, rootID) when built via Analyze/registry, or plan when built via bytecode compiler.
 	arena       *NodeArena
 	rootID      int
@@ -46,7 +55,7 @@ func Describe(tb testing.TB, name string, fn func(*Spec)) {
 	if tb != nil {
 		backend = asTestBackend(tb)
 	}
-	s := &Spec{tb: tb, backend: backend, arena: CurrentArena(), rootID: rootID}
+	s := &Spec{tb: tb, backend: backend, arena: CurrentArena(), rootID: rootID, registry: currentRegistry()}
 	if fn != nil {
 		fn(s)
 	}
@@ -64,16 +73,11 @@ func describeWithCompiler(tb testing.TB, name string, rep report.EventReporter, 
 func describeWithCompilerContext(tb testing.TB, runCtx context.Context, name string, rep report.EventReporter, fn func(*Spec), flat bool) []proposalControllerResult {
 	c := newBytecodeCompiler()
 	c.PushScope(name)
-	pushCompiler(c)
-	defer func() {
-		popCompiler()
-		c.PopScope()
-	}()
 	var backend testBackend
 	if tb != nil {
 		backend = asTestBackend(tb)
 	}
-	s := &Spec{tb: tb, backend: backend, reporter: rep, flat: flat}
+	s := &Spec{tb: tb, backend: backend, reporter: rep, flat: flat, compiler: c}
 	if fn != nil {
 		fn(s)
 	}
@@ -92,13 +96,10 @@ func BuildSuite(tb testing.TB, name string, fn func(*Spec)) *CompiledSuite {
 	if currentRegistry() == nil {
 		c := newBytecodeCompiler()
 		c.PushScope(name)
-		pushCompiler(c)
-		s := &Spec{tb: tb, backend: nil}
+		s := &Spec{tb: tb, backend: nil, compiler: c}
 		if fn != nil {
 			fn(s)
 		}
-		popCompiler()
-		c.PopScope()
 		s.plan = c.TakePlan()
 		s.Compile()
 		return s.suite
@@ -110,7 +111,7 @@ func BuildSuite(tb testing.TB, name string, fn func(*Spec)) *CompiledSuite {
 		return nil
 	}
 	defer pop()
-	s := &Spec{tb: tb, backend: nil, arena: CurrentArena(), rootID: rootID}
+	s := &Spec{tb: tb, backend: nil, arena: CurrentArena(), rootID: rootID, registry: currentRegistry()}
 	if fn != nil {
 		fn(s)
 	}
@@ -135,7 +136,7 @@ func DescribeWithReporter(tb testing.TB, name string, rep report.EventReporter, 
 	if tb != nil {
 		backend = asTestBackend(tb)
 	}
-	s := &Spec{tb: tb, backend: backend, reporter: rep, arena: CurrentArena(), rootID: rootID}
+	s := &Spec{tb: tb, backend: backend, reporter: rep, arena: CurrentArena(), rootID: rootID, registry: currentRegistry()}
 	if fn != nil {
 		fn(s)
 	}
@@ -162,7 +163,7 @@ func DescribeFlat(tb testing.TB, name string, fn func(*Spec)) {
 	if tb != nil {
 		backend = asTestBackend(tb)
 	}
-	s := &Spec{tb: tb, backend: backend, arena: CurrentArena(), rootID: rootID, flat: true}
+	s := &Spec{tb: tb, backend: backend, arena: CurrentArena(), rootID: rootID, flat: true, registry: currentRegistry()}
 	if fn != nil {
 		fn(s)
 	}
@@ -189,7 +190,7 @@ func DescribeFlatWithReporter(tb testing.TB, name string, rep report.EventReport
 	if tb != nil {
 		backend = asTestBackend(tb)
 	}
-	s := &Spec{tb: tb, backend: backend, reporter: rep, arena: CurrentArena(), rootID: rootID, flat: true}
+	s := &Spec{tb: tb, backend: backend, reporter: rep, arena: CurrentArena(), rootID: rootID, flat: true, registry: currentRegistry()}
 	if fn != nil {
 		fn(s)
 	}
@@ -258,16 +259,21 @@ func (s *Spec) Describe(name string, fn func(*Spec)) {
 	if s == nil || fn == nil {
 		return
 	}
-	if c := currentCompiler(); c != nil {
+	if c := s.compiler; c != nil {
 		c.PushScope(name)
 		defer c.PopScope()
-		fn(&Spec{tb: s.tb, backend: s.backend, reporter: s.reporter, seed: s.seed, hasSeed: s.hasSeed})
+		fn(&Spec{tb: s.tb, backend: s.backend, reporter: s.reporter, seed: s.seed, hasSeed: s.hasSeed, compiler: c})
+		return
+	}
+	child := &Spec{tb: s.tb, backend: s.backend, reporter: s.reporter, seed: s.seed, hasSeed: s.hasSeed, registry: s.registry}
+	if s.registry == nil {
+		fn(child)
 		return
 	}
 	file, line := callerLocation(2)
-	_, pop := enterAnalyzeNode(DescribeNode, name, file, line, nil)
+	_, pop := s.registry.enterNode(DescribeNode, name, file, line, nil)
 	defer pop()
-	fn(&Spec{tb: s.tb, backend: s.backend, reporter: s.reporter, seed: s.seed, hasSeed: s.hasSeed})
+	fn(child)
 }
 
 // When starts a when block. fn may be func(*Spec) or func() for legacy scope.
@@ -275,26 +281,34 @@ func (s *Spec) When(name string, fn interface{}) {
 	if s == nil || fn == nil {
 		return
 	}
-	if c := currentCompiler(); c != nil {
+	if c := s.compiler; c != nil {
 		c.PushScope(name)
 		defer c.PopScope()
 		switch f := fn.(type) {
 		case func(*Spec):
-			f(&Spec{tb: s.tb, backend: s.backend, reporter: s.reporter, seed: s.seed, hasSeed: s.hasSeed})
+			f(&Spec{tb: s.tb, backend: s.backend, reporter: s.reporter, seed: s.seed, hasSeed: s.hasSeed, compiler: c})
 		case func():
 			f()
 		}
 		return
 	}
-	file, line := callerLocation(2)
-	_, pop := enterAnalyzeNode(WhenNode, name, file, line, nil)
-	defer pop()
-	switch f := fn.(type) {
-	case func(*Spec):
-		f(&Spec{tb: s.tb, backend: s.backend, reporter: s.reporter, seed: s.seed, hasSeed: s.hasSeed})
-	case func():
-		f()
+	child := &Spec{tb: s.tb, backend: s.backend, reporter: s.reporter, seed: s.seed, hasSeed: s.hasSeed, registry: s.registry}
+	runFn := func() {
+		switch f := fn.(type) {
+		case func(*Spec):
+			f(child)
+		case func():
+			f()
+		}
 	}
+	if s.registry == nil {
+		runFn()
+		return
+	}
+	file, line := callerLocation(2)
+	_, pop := s.registry.enterNode(WhenNode, name, file, line, nil)
+	defer pop()
+	runFn()
 }
 
 // It registers a spec.
@@ -302,12 +316,15 @@ func (s *Spec) It(name string, fn func(*Context)) {
 	if s == nil {
 		return
 	}
-	if c := currentCompiler(); c != nil {
+	if c := s.compiler; c != nil {
 		c.EmitIt(name, fn)
 		return
 	}
+	if s.registry == nil {
+		return
+	}
 	file, line := callerLocation(2)
-	_, pop := enterAnalyzeNode(ItNode, name, file, line, fn)
+	_, pop := s.registry.enterNode(ItNode, name, file, line, fn)
 	pop()
 }
 
@@ -316,11 +333,13 @@ func (s *Spec) BeforeEach(fn func(*Context)) {
 	if s == nil || fn == nil {
 		return
 	}
-	if c := currentCompiler(); c != nil {
+	if c := s.compiler; c != nil {
 		c.AppendBefore(fn)
 		return
 	}
-	AppendBeforeHook(fn)
+	if s.registry != nil {
+		s.registry.appendBeforeHook(fn)
+	}
 }
 
 // AfterEach appends an after-each hook to the current node.
@@ -328,11 +347,13 @@ func (s *Spec) AfterEach(fn func(*Context)) {
 	if s == nil || fn == nil {
 		return
 	}
-	if c := currentCompiler(); c != nil {
+	if c := s.compiler; c != nil {
 		c.AppendAfter(fn)
 		return
 	}
-	AppendAfterHook(fn)
+	if s.registry != nil {
+		s.registry.appendAfterHook(fn)
+	}
 }
 
 // RandomSeed sets the RNG seed for path/context in this spec subtree.
@@ -347,14 +368,17 @@ func (s *Spec) runPathWithContext(name string, gen *PathGenerator, _ interface{}
 	if s == nil || fn == nil {
 		return
 	}
-	if c := currentCompiler(); c != nil {
+	if c := s.compiler; c != nil {
 		c.SetPathGen(gen)
 		c.EmitIt(name, fn)
 		return
 	}
+	if s.registry == nil {
+		return
+	}
 	file, line := callerLocation(2)
-	_, pop := enterAnalyzeNode(ItNode, name, file, line, fn)
-	SetPathGen(gen)
+	_, pop := s.registry.enterNode(ItNode, name, file, line, fn)
+	s.registry.setPathGen(gen)
 	pop()
 }
 

--- a/specs/spec_concurrency_test.go
+++ b/specs/spec_concurrency_test.go
@@ -1,0 +1,189 @@
+package specs
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestBuildSuiteConcurrentTopLevelSuitesDoNotCrossContaminate verifies #25's fix for the bytecode
+// compiler path (top-level Describe/BuildSuite with no Analyze wrapping it): two goroutines building
+// unrelated suites concurrently must never have one goroutine's It land in the other's plan.
+//
+// Deterministic reproduction, not a timing gamble: both goroutines are let run until each has pushed
+// its own compiler and is blocked mid-body, so an implementation using a single shared "current
+// compiler" (the pre-fix global stack) would deterministically resolve both It calls to whichever
+// compiler was pushed last, corrupting one of the two plans regardless of scheduling order.
+func TestBuildSuiteConcurrentTopLevelSuitesDoNotCrossContaminate(t *testing.T) {
+	aReady, bReady := make(chan struct{}), make(chan struct{})
+	aGo, bGo := make(chan struct{}), make(chan struct{})
+
+	var suiteA, suiteB *CompiledSuite
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		suiteA = BuildSuite(nil, "SuiteA", func(s *Spec) {
+			close(aReady)
+			<-aGo
+			s.It("a1", func(ctx *Context) {})
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		suiteB = BuildSuite(nil, "SuiteB", func(s *Spec) {
+			close(bReady)
+			<-bGo
+			s.It("b1", func(ctx *Context) {})
+		})
+	}()
+
+	<-aReady
+	<-bReady
+	close(aGo)
+	close(bGo)
+	wg.Wait()
+
+	if suiteA == nil || suiteB == nil {
+		t.Fatal("expected both suites to be built")
+	}
+	if got := suiteA.Plan.Names; len(got) != 1 || got[0] != "a1" {
+		t.Fatalf("suite A plan corrupted: got names %v, want [a1]", got)
+	}
+	if got := suiteB.Plan.Names; len(got) != 1 || got[0] != "b1" {
+		t.Fatalf("suite B plan corrupted: got names %v, want [b1]", got)
+	}
+}
+
+// TestAnalyzeConcurrentSuitesDoNotCrossContaminate verifies #25's fix for the registry/arena path
+// (Describe nested inside Analyze): two goroutines each running their own Analyze(func(){ Describe(...) })
+// concurrently must not have one goroutine's It land in the other's arena. Same deterministic barrier
+// technique as the compiler-path test above — both Describe calls push their registry and reach the
+// blocked It call before either releases, so a shared top-of-stack lookup would deterministically
+// resolve to whichever registry was pushed last for both goroutines.
+func TestAnalyzeConcurrentSuitesDoNotCrossContaminate(t *testing.T) {
+	aReady, bReady := make(chan struct{}), make(chan struct{})
+	aGo, bGo := make(chan struct{}), make(chan struct{})
+
+	var treeA, treeB *SuiteTree
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		treeA = Analyze(func() {
+			Describe(nil, "RootA", func(s *Spec) {
+				close(aReady)
+				<-aGo
+				s.It("a1", func(ctx *Context) {})
+			})
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		treeB = Analyze(func() {
+			Describe(nil, "RootB", func(s *Spec) {
+				close(bReady)
+				<-bGo
+				s.It("b1", func(ctx *Context) {})
+			})
+		})
+	}()
+
+	<-aReady
+	<-bReady
+	close(aGo)
+	close(bGo)
+	wg.Wait()
+
+	assertSingleItLeaf(t, treeA, "RootA", "a1")
+	assertSingleItLeaf(t, treeB, "RootB", "b1")
+}
+
+// assertSingleItLeaf checks tree has exactly one Describe child named describeName, itself with
+// exactly one It child named itName.
+func assertSingleItLeaf(t *testing.T, tree *SuiteTree, describeName, itName string) {
+	t.Helper()
+	if tree == nil || tree.Arena == nil {
+		t.Fatalf("expected a suite tree for %q", describeName)
+	}
+	rootID := tree.RootID
+	children := tree.Arena.Children[rootID]
+	if len(children) != 1 {
+		t.Fatalf("%q: expected 1 root child, got %d", describeName, len(children))
+	}
+	descID := children[0]
+	desc := &tree.Arena.Nodes[descID]
+	if desc.Name != describeName || desc.Type != DescribeNode {
+		t.Fatalf("%q: expected describe node %q, got %+v", describeName, describeName, desc)
+	}
+	leafChildren := tree.Arena.Children[descID]
+	if len(leafChildren) != 1 {
+		t.Fatalf("%q: expected 1 it child under %q, got %d: %v", describeName, describeName, len(leafChildren), leafChildren)
+	}
+	leafID := leafChildren[0]
+	leaf := &tree.Arena.Nodes[leafID]
+	if leaf.Name != itName || leaf.Type != ItNode {
+		t.Fatalf("%q: expected it node %q, got %+v", describeName, itName, leaf)
+	}
+}
+
+// TestNestedDescribeWhenStillWorksAfterExplicitThreading is a plain sanity check (no concurrency)
+// that threading compiler/registry explicitly through Spec (instead of resolving via package-level
+// global state) didn't change behavior for ordinary nested Describe/When/BeforeEach/AfterEach/It use,
+// in both the bytecode-compiler path (top-level Describe, no Analyze) and the registry path (Describe
+// nested inside Analyze).
+func TestNestedDescribeWhenStillWorksAfterExplicitThreading(t *testing.T) {
+	t.Run("compiler path", func(t *testing.T) {
+		var order []string
+		suite := BuildSuite(nil, "Root", func(s *Spec) {
+			s.BeforeEach(func(ctx *Context) { order = append(order, "root-before") })
+			s.Describe("Mid", func(s *Spec) {
+				s.When("Sub", func(s *Spec) {
+					s.BeforeEach(func(ctx *Context) { order = append(order, "sub-before") })
+					s.It("leaf", func(ctx *Context) { order = append(order, "leaf") })
+					s.AfterEach(func(ctx *Context) { order = append(order, "sub-after") })
+				})
+			})
+		})
+		if len(suite.Plan.Names) != 1 || suite.Plan.Names[0] != "leaf" {
+			t.Fatalf("expected one spec named leaf, got %v", suite.Plan.Names)
+		}
+		if want := "Root/Mid/Sub/leaf"; suite.Plan.FullNames[0] != want {
+			t.Fatalf("expected full name %q, got %q", want, suite.Plan.FullNames[0])
+		}
+	})
+
+	t.Run("registry path", func(t *testing.T) {
+		tree := Analyze(func() {
+			Describe(nil, "Root", func(s *Spec) {
+				s.Describe("Mid", func(s *Spec) {
+					s.When("Sub", func(s *Spec) {
+						s.It("leaf", func(ctx *Context) {})
+					})
+				})
+			})
+		})
+		rootID := tree.RootID
+		topID := tree.Arena.Children[rootID][0]
+		top := &tree.Arena.Nodes[topID]
+		if top.Name != "Root" || top.Type != DescribeNode {
+			t.Fatalf("expected Root describe node, got %+v", top)
+		}
+		midID := tree.Arena.Children[topID][0]
+		mid := &tree.Arena.Nodes[midID]
+		if mid.Name != "Mid" || mid.Type != DescribeNode {
+			t.Fatalf("expected Mid describe node, got %+v", mid)
+		}
+		subID := tree.Arena.Children[midID][0]
+		sub := &tree.Arena.Nodes[subID]
+		if sub.Name != "Sub" || sub.Type != WhenNode {
+			t.Fatalf("expected Sub when node, got %+v", sub)
+		}
+		leafID := tree.Arena.Children[subID][0]
+		leaf := &tree.Arena.Nodes[leafID]
+		if leaf.Name != "leaf" || leaf.Type != ItNode {
+			t.Fatalf("expected leaf it node, got %+v", leaf)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`Describe`/`BuildSuite`/`Analyze` resolved "the current compiler" and "the current registry" via two package-level global stacks (`activeCompiler`, `activeRegistries`), shared **process-wide across every goroutine**.

Two `t.Parallel()` top-level tests, each calling `specs.Describe(...)` (or `Analyze(...)`) concurrently, could each push their own compiler/registry onto the same shared stack. From then on, any `It`/`BeforeEach`/`AfterEach` call in either goroutine silently resolved to *whichever one happened to be on top of the shared stack* — corrupting both suites' plans/trees with no error or panic. This is reachable through the plain public API; the compiler path (`Describe` without `Analyze`) had no lock protecting it at all.

## Fix

- `Spec` now carries the exact `compiler`/`registry` it (and anything it constructs for a nested `Describe`/`When`) should write into, threaded explicitly from the root instead of resolved via global state on every call. `It`/`BeforeEach`/`AfterEach`/`Describe`/`When` all read `s.compiler`/`s.registry` directly.
- `activeCompiler` is **removed entirely**: both of its push sites already had the compiler as a local variable in scope, so nothing needed the global stack once `Spec` carried it explicitly.
- `activeRegistries` can't be removed the same way, since `Analyze(fn func())`'s callback has no `Spec` handle for a nested top-level `Describe` to inherit from — genuine global lookup is still needed there. It's now **keyed per goroutine** (`map[int64][]*registry`, via a `goroutineID()` helper parsing `runtime.Stack`'s `"goroutine N"` line), looked up only at true entry points (`Describe`, `BuildSuite`, `Analyze`) — never inside the hot `It`/`BeforeEach`/`AfterEach` path.
- `analyzeLock`, which fully serialized *every* `Analyze()` call process-wide, is removed. It was an accidental workaround for this same race — goroutine-scoped registries make it unnecessary, and removing it restores genuine concurrent `Analyze()` suite construction (this library already supports parallel test execution; it should support parallel suite *construction* too).
- `Analyze()`'s registry pop is now `defer`red immediately after push, so a panic inside `fn` no longer leaks that goroutine's stack entry forever.
- Removed a redundant `PopScope()` call after `TakePlan()` in `describeWithCompilerContext`/`BuildSuite`: `TakePlan` already calls `reset()`, which unconditionally clears `nameStack` and returns the compiler to its `sync.Pool` — so that trailing pop was touching a possibly-already-repooled object for no effect.

Scope is confined to `spec.go`, `compiler.go`, `registry.go`, and their tests, per plan.

## Tests

`specs/spec_concurrency_test.go` adds three regression tests:

1. **`TestBuildSuiteConcurrentTopLevelSuitesDoNotCrossContaminate`** — a barrier/channel-based test building two suites concurrently through `BuildSuite` (compiler path). Both goroutines are held mid-body (each has pushed its own compiler) before either is released, so the reproduction is deterministic, not timing-dependent. Asserts each `It` lands only in its own plan.
2. **`TestAnalyzeConcurrentSuitesDoNotCrossContaminate`** — the same pattern for two goroutines calling `Analyze`+`Describe` (registry path). Asserts each `It` lands only in its own arena tree.
3. **`TestNestedDescribeWhenStillWorksAfterExplicitThreading`** — a synchronous sanity test (both paths) proving the explicit-threading refactor didn't change ordinary, non-concurrent `Describe`/`When`/`BeforeEach`/`AfterEach`/`It` behavior.

### Proof against pre-fix code

Verified via `git stash` (keeping only the new test file) that both concurrency tests genuinely catch the bug:

- The **compiler-path** test fails deterministically, 5/5 runs, with visibly cross-contaminated plan names — e.g. suite A's plan containing suite B's spec (`[b1 a1], [a1]`).
- The **registry-path** test **deadlocks** deterministically on the old `analyzeLock`: goroutine A holds it for the entire `Analyze` call while blocked waiting on goroutine B, and B can't even start because it's blocked trying to acquire the same lock. This is itself a strong signal `analyzeLock` had to go — it wasn't just redundant, it actively prevented the two goroutines in this (and any real-world) scenario from making progress at all.

## Validation

- `gofmt -l` — clean
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all packages `ok`
- `go test ./... -race -count=2` — all packages `ok`, zero data races
- `make build` — clean
- `make lint` — 0 issues

Fixes #25.
