### PR TITLE
fix(specs): recover panics in the default execution path

### DIFF
--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -4,6 +4,7 @@ package specs
 import (
 	"context"
 	"io"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"testing"
@@ -230,15 +231,58 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 	return proposalControllerResult{}
 }
 
+// runProgram executes one spec's instructions directly in the caller's goroutine (the default,
+// non-path, non-isolated path — see runIsolatedCaseDirect for the path-generated equivalent).
+// A panic anywhere in the before/body instructions is recovered so it fails this one spec instead
+// of crashing the process; after-hook instructions still run regardless, each isolated from the
+// others so one panicking after-hook doesn't stop the rest.
 func runProgram(program []Instruction, ctx *Context, path *PathValues) {
 	if path != nil {
 		ctx.SetPathValues(*path)
 	}
+	var after []Instruction
 	for _, inst := range program {
+		if inst.Code == OpAfterHook && inst.Fn != nil {
+			after = append(after, inst)
+		}
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil && !isExpectedAbort(recovered) {
+			ctx.recordFailure()
+			ctx.backend.Errorf("panic: %v\n%s", recovered, debug.Stack())
+		}
+		for _, inst := range after {
+			runAfterInstructionRecovered(ctx, inst)
+		}
+	}()
+	for _, inst := range program {
+		if inst.Code == OpAfterHook {
+			continue
+		}
 		if inst.Fn != nil {
 			inst.Fn(ctx)
 		}
 	}
+}
+
+// runAfterInstructionRecovered runs a single after-hook instruction, recovering any panic so it
+// can't stop the remaining after-hooks for this spec.
+func runAfterInstructionRecovered(ctx *Context, inst Instruction) {
+	defer func() {
+		if recovered := recover(); recovered != nil && !isExpectedAbort(recovered) {
+			ctx.recordFailure()
+			ctx.backend.Errorf("panic in after hook: %v\n%s", recovered, debug.Stack())
+		}
+	}()
+	inst.Fn(ctx)
+}
+
+// isExpectedAbort reports whether a recovered value is the isolatedCaseAbort sentinel a
+// controlled testBackend uses to stop one case via FailNow/Fatal/Fatalf — an already-recorded
+// stop, not an unexpected panic to report.
+func isExpectedAbort(recovered any) bool {
+	_, ok := recovered.(isolatedCaseAbort)
+	return ok
 }
 
 // isolatedCaseAbort lets a controlled backend stop one isolated case without

--- a/specs/execution_plan_recovery_test.go
+++ b/specs/execution_plan_recovery_test.go
@@ -1,0 +1,110 @@
+package specs
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestExecutionPlanRecoversPanicAndContinues proves issue #15's core requirement for the default
+// (non-path) execution path: a spec body that panics no longer crashes the process — it's recorded
+// as that spec's failure, and the remaining specs in the plan still run.
+func TestExecutionPlanRecoversPanicAndContinues(t *testing.T) {
+	var ranSpec2 bool
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{
+			{Code: OpBody, Fn: func(*Context) { panic("boom") }},
+			{Code: OpBody, Fn: func(*Context) { ranSpec2 = true }},
+		},
+		ProgramStart: []int{0, 1},
+		ProgramLen:   []int{1, 1},
+		PathGens:     []*PathGenerator{nil, nil},
+	}
+	backend := &controlledBackend{}
+	runPlanFlatNoSubtests(context.Background(), backend, nil, plan)
+
+	if !ranSpec2 {
+		t.Fatal("expected spec2 to run after spec1 panicked, but it didn't — the panic aborted the whole plan")
+	}
+	if len(backend.errors) != 1 {
+		t.Fatalf("expected exactly one recorded failure for the panicking spec, got %v", backend.errors)
+	}
+	if !strings.Contains(backend.errors[0], "boom") {
+		t.Fatalf("expected the panic message in the recorded failure, got %q", backend.errors[0])
+	}
+}
+
+// TestRunProgramAfterHookSurvivesBodyPanic proves after-hooks still run when the body panics,
+// matching runIsolatedCaseDirect's established pattern for the path-generated case.
+func TestRunProgramAfterHookSurvivesBodyPanic(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var afterRan bool
+	program := []Instruction{
+		{Code: OpBody, Fn: func(*Context) { panic("boom") }},
+		{Code: OpAfterHook, Fn: func(*Context) { afterRan = true }},
+	}
+	runProgram(program, ctx, nil)
+
+	if !afterRan {
+		t.Fatal("expected the after hook to run despite the body panic")
+	}
+	if !ctx.failed {
+		t.Fatal("expected ctx.failed to be set after an unrecovered body panic")
+	}
+	if len(backend.errors) != 1 || !strings.Contains(backend.errors[0], "boom") {
+		t.Fatalf("expected one recorded failure mentioning the panic message, got %v", backend.errors)
+	}
+}
+
+// TestRunProgramDoesNotDoubleReportExpectedAbort proves that isolatedCaseAbort — the sentinel a
+// controlled testBackend panics from FailNow/Fatal/Fatalf to stop one case — is recognized as an
+// already-recorded stop, not reported a second time as an unexpected panic. It also confirms the
+// after hook still runs, matching an ordinary FailNow.
+func TestRunProgramDoesNotDoubleReportExpectedAbort(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var afterRan bool
+	program := []Instruction{
+		{Code: OpBody, Fn: func(c *Context) { c.backend.FailNow() }},
+		{Code: OpAfterHook, Fn: func(*Context) { afterRan = true }},
+	}
+	runProgram(program, ctx, nil)
+
+	if !backend.failNow {
+		t.Fatal("expected the backend to have recorded FailNow")
+	}
+	if !afterRan {
+		t.Fatal("expected the after hook to still run after an expected abort")
+	}
+	if len(backend.errors) != 0 {
+		t.Fatalf("expected no unexpected-panic error for an expected abort sentinel, got %v", backend.errors)
+	}
+}
+
+// TestRunProgramAfterHookPanicDoesNotStopSiblingAfterHooks proves one panicking after-hook doesn't
+// prevent the remaining after-hooks (for the same spec) from running.
+func TestRunProgramAfterHookPanicDoesNotStopSiblingAfterHooks(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var secondAfterRan bool
+	program := []Instruction{
+		{Code: OpBody, Fn: func(*Context) {}},
+		{Code: OpAfterHook, Fn: func(*Context) { panic("after boom") }},
+		{Code: OpAfterHook, Fn: func(*Context) { secondAfterRan = true }},
+	}
+	runProgram(program, ctx, nil)
+
+	if !secondAfterRan {
+		t.Fatal("expected the second after hook to run despite the first one panicking")
+	}
+	found := false
+	for _, e := range backend.errors {
+		if strings.Contains(e, "after boom") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected the after-hook panic to be recorded as a failure, got %v", backend.errors)
+	}
+}


### PR DESCRIPTION
Part of #15.

## Problem

`execution_plan.go`'s default (non-path, non-isolated) per-spec execution — `runExecutionContext` → `runProgram`, the path every ordinary `Describe`/`It` suite runs through — had no `recover()` at all. A genuine panic (nil pointer, index out of range, an explicit `panic(...)` in a spec body) propagated straight out of `runProgram`, through `runPlanFlatNoSubtests`'s loop, and crashed the whole test binary.

Confirmed with a real run: stashed the fix, kept the new test file, and ran the full `specs` package. `testing.tRunner` recovered just enough to attribute the panic to the panicking test and print its stack, then **re-panicked**, killing the process. Only 9 of 100+ test functions in the package got a chance to run before that — everything alphabetically after the panicking one, including entire unrelated test files, silently never ran.

The path-generated case (`Paths().It()`, via `runIsolatedCaseDirect`) already had the correct pattern for this. This PR brings the default path in line with it.

## Fix

- `runProgram` now separates a spec's after-hook instructions from its before/body instructions, and defers a `recover()` around before/body execution. A recovered panic is reported via `backend.Errorf` with message + stack trace and marks `ctx.failed`, then execution returns normally — the plan's loop continues to the next spec instead of crashing.
- After-hook instructions always run following that deferred recover, regardless of whether the body panicked, matching `runIsolatedCaseDirect`. Each after-hook instruction is recovered **individually** (`runAfterInstructionRecovered`), so one panicking after-hook can't stop its siblings.
- The `isolatedCaseAbort{}` sentinel is recognized (`isExpectedAbort`) as an already-recorded stop, not reported a second time as an unexpected panic — for consistency with `runIsolatedCaseDirect`, and because a controlled `testBackend` (as `execution_plan_test.go`'s `controlledBackend` already is elsewhere) could reach this code path directly.

### Scope correction on `parallelAbort{}`

The original plan for this PR called for recognizing `parallelAbort{}` as an expected sentinel here too. Tracing its only construction site: it's built exclusively inside `program.go`'s `parallelStep`, which already recovers it in its own per-goroutine `defer` *before* any result ever reaches `execution_plan.go`. Nothing in this file can ever observe a `parallelAbort{}` panic — there's nothing to special-case. `Runner.Run` (which `parallelStep` feeds into) is a separate compiled model (`Program`/`group`, not `ExecutionPlan`) with no recover of its own; that's one of the follow-up issues below, not something reachable from this file.

### Side effect worth flagging for review

Pulling after-hook execution into a `defer` also means a spec's real `testing.T.Fatal`/`FailNow` — which unwinds via `runtime.Goexit`, not `panic` — now lets that spec's after-hooks run before the goroutine exits. They previously did not, since the old flat instruction loop simply never reached them once `Goexit` started unwinding. Whether a `Fatal` in spec *i* should still abandon specs *i+1..n* in this flat, non-subtest execution model is a separate, pre-existing question this PR does not otherwise touch or fix.

## Tests (`specs/execution_plan_recovery_test.go`)

- **`TestExecutionPlanRecoversPanicAndContinues`** — a panicking spec no longer crashes `runPlanFlatNoSubtests`; the next spec in the plan still runs, and the panic is recorded as exactly one failure.
- **`TestRunProgramAfterHookSurvivesBodyPanic`** — the after-hook runs despite the body panic; `ctx.failed` is set; the failure is recorded with the panic message.
- **`TestRunProgramDoesNotDoubleReportExpectedAbort`** — `FailNow`'s `isolatedCaseAbort` sentinel is not reported as an unexpected panic, and the after-hook still runs.
- **`TestRunProgramAfterHookPanicDoesNotStopSiblingAfterHooks`** — one panicking after-hook doesn't prevent the next after-hook from running; the panic is still recorded.

### Proof against pre-fix code

`git stash`ed `execution_plan.go` (kept the new test file) and ran the full `specs` package: process crash after only 9/100+ test functions ran, as described above. `git stash pop` restored the fix; full suite passes.

## Validation

- `gofmt -l` — clean
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — all 19 packages `ok`
- `go test ./... -race -count=2` — all 19 packages `ok`, zero data races
- `make build` — clean
- `make lint` — 0 issues

## Follow-ups

This PR is scoped to `execution_plan.go`'s default execution path only. Still with no panic recovery: `Runner.Run` (`runner.go` — needs its own contract decision first: does a panic in one spec abort only that spec while preserving the group's `after`, abort the whole group, or something else), `BlockRunner` (`block_runner.go`), `MinimalRunner` (`minimal_runner.go`), `BytecodeRunner` (`runner_bytecode.go`), and `scheduler.runWorker` (`scheduler.go`). Follow-up issues will be filed for each; #15 stays open until all are covered.
