### PR TITLE
fix(specs): recover panics in Runner.Run (grouped before/specs/after)

### DIFF
--- a/specs/runner.go
+++ b/specs/runner.go
@@ -120,12 +120,11 @@ func runSpecsRecovered(ctx *Context, specs []step) {
 }
 
 // runAfterRecovered runs a group's after hooks in reverse order, recovering each individually.
+// Unlike before/specs, this does not check FailFast between hooks: FailFast decides whether we run
+// more specs/groups, not whether we leave resources uncleaned. Every after hook always runs.
 func runAfterRecovered(ctx *Context, after []step) {
 	for i := len(after) - 1; i >= 0; i-- {
 		runStepRecovered(ctx, after[i], "panic in after hook")
-		if ctx.failFast && ctx.failed {
-			return
-		}
 	}
 }
 

--- a/specs/runner.go
+++ b/specs/runner.go
@@ -1,7 +1,10 @@
 // runner.go executes a compiled Program. No hook resolution at runtime; no allocations in the loop.
 package specs
 
-import "testing"
+import (
+	"runtime/debug"
+	"testing"
+)
 
 // Runner runs a compiled Program against a test backend. One context from the pool, reused for every step.
 type Runner struct {
@@ -21,6 +24,9 @@ func NewRunnerFromProgram(program *Program) *Runner {
 
 // Run executes all groups in order. Within each group: before once, all specs, then after once (reverse order).
 // Zero allocations in the loop; deterministic.
+//
+// A panic in before, a spec, or an after hook is recovered instead of crashing the process — see
+// runGroup for the exact contract (which specs still run, whether after still runs).
 func (r *Runner) Run(tb testing.TB) {
 	if r == nil || r.program == nil || tb == nil || len(r.program.Groups) == 0 {
 		return
@@ -38,43 +44,100 @@ func (r *Runner) Run(tb testing.TB) {
 		ctx.SetFailFast(true)
 	}
 
-	groups := r.program.Groups
+	runGroups(ctx, r.program.Groups)
+}
+
+// runGroups runs each group in order, stopping before the next group if FailFast is set and a
+// previous group left ctx failed (an ordinary assertion failure or a recovered panic — recordFailure
+// marks both the same way, so this check needs no panic-specific case). Split out from Run so the
+// group-iteration/FailFast contract can be tested without a real testing.TB.
+func runGroups(ctx *Context, groups []group) {
 	n := len(groups)
 	for gi := 0; gi < n; gi++ {
 		if ctx.failFast && ctx.failed {
 			break
 		}
-		g := &groups[gi]
-		before := g.before
-		specs := g.specs
-		after := g.after
-
-		nb := len(before)
-		for i := 0; i < nb; i++ {
-			before[i](ctx)
-			if ctx.failFast && ctx.failed {
-				break
-			}
-		}
+		runGroup(ctx, &groups[gi])
 		if ctx.failFast && ctx.failed {
 			break
-		}
-		ns := len(specs)
-		for i := 0; i < ns; i++ {
-			specs[i](ctx)
-			if ctx.failFast && ctx.failed {
-				break
-			}
-		}
-		if ctx.failFast && ctx.failed {
-			break
-		}
-		na := len(after)
-		for i := na - 1; i >= 0; i-- {
-			after[i](ctx)
-			if ctx.failFast && ctx.failed {
-				break
-			}
 		}
 	}
+}
+
+// runGroup runs one group's before, specs, and after against ctx.
+//
+// before runs as one recovered unit: a panic in any before hook stops the remaining before hooks
+// in this group (later ones may depend on earlier ones' side effects) and skips this group's specs
+// entirely — they can't be trusted to run meaningfully against setup that never completed.
+//
+// Each spec is recovered individually, so one panicking spec doesn't stop its siblings — matching
+// the default execution path's contract (see execution_plan.go's runProgram).
+//
+// after always runs, via defer: whether before or a spec panicked, or a spec called a real
+// t.Fatal/FailNow (runtime.Goexit unwinds through this defer same as a panic would), after gets a
+// chance to clean up whatever before did set up. Each after hook is recovered individually, so one
+// panicking after hook doesn't stop its siblings from attempting to run.
+func runGroup(ctx *Context, g *group) {
+	defer runAfterRecovered(ctx, g.after)
+
+	if !runBeforeRecovered(ctx, g.before) {
+		return
+	}
+	if ctx.failFast && ctx.failed {
+		return
+	}
+	runSpecsRecovered(ctx, g.specs)
+}
+
+// runBeforeRecovered runs a group's before hooks in order. Returns false if a panic stopped setup
+// partway through, in which case the caller must not run this group's specs.
+func runBeforeRecovered(ctx *Context, before []step) (ok bool) {
+	ok = true
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			ok = false
+			ctx.recordFailure()
+			ctx.backend.Errorf("panic in before hook: %v\n%s", recovered, debug.Stack())
+		}
+	}()
+	for _, b := range before {
+		b(ctx)
+		if ctx.failFast && ctx.failed {
+			return
+		}
+	}
+	return
+}
+
+// runSpecsRecovered runs a group's specs in order, recovering each one individually.
+func runSpecsRecovered(ctx *Context, specs []step) {
+	for _, s := range specs {
+		runStepRecovered(ctx, s, "panic")
+		if ctx.failFast && ctx.failed {
+			return
+		}
+	}
+}
+
+// runAfterRecovered runs a group's after hooks in reverse order, recovering each individually.
+func runAfterRecovered(ctx *Context, after []step) {
+	for i := len(after) - 1; i >= 0; i-- {
+		runStepRecovered(ctx, after[i], "panic in after hook")
+		if ctx.failFast && ctx.failed {
+			return
+		}
+	}
+}
+
+// runStepRecovered runs a single step, recovering a panic so it fails just this step (recorded via
+// ctx.recordFailure + ctx.backend.Errorf with message and stack trace) instead of crashing the
+// process. label distinguishes a before/spec panic from an after-hook panic in the reported message.
+func runStepRecovered(ctx *Context, s step, label string) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			ctx.recordFailure()
+			ctx.backend.Errorf("%s: %v\n%s", label, recovered, debug.Stack())
+		}
+	}()
+	s(ctx)
 }

--- a/specs/runner_recovery_test.go
+++ b/specs/runner_recovery_test.go
@@ -105,6 +105,39 @@ func TestRunGroupAfterHookPanicDoesNotStopSiblingAfterHooks(t *testing.T) {
 	}
 }
 
+// TestRunGroupAfterHookPanicDoesNotStopSiblingAfterHooksUnderFailFast proves that FailFast does not
+// leak into after-hook execution: FailFast decides whether we run more specs/groups, not whether we
+// leave resources uncleaned. Even with FailFast on and the first-executed after hook panicking (which
+// sets ctx.failed), the remaining after hooks in this group must still run.
+func TestRunGroupAfterHookPanicDoesNotStopSiblingAfterHooksUnderFailFast(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	ctx.SetFailFast(true)
+	var secondRan bool
+	// after runs in reverse order (index len-1 down to 0), so the second element here runs first.
+	g := &group{
+		specs: []step{func(*Context) {}},
+		after: []step{
+			func(*Context) { secondRan = true },
+			func(*Context) { panic("after boom") },
+		},
+	}
+	runGroup(ctx, g)
+
+	if !secondRan {
+		t.Fatal("expected the sibling after hook to run despite FailFast and the first-executed one panicking")
+	}
+	found := false
+	for _, e := range backend.errors {
+		if strings.Contains(e, "after boom") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected the after-hook panic to be recorded as a failure, got %v", backend.errors)
+	}
+}
+
 // TestRunGroupFailFastStopsRemainingSpecsButAfterStillRuns proves the contract decided for #62: a
 // panic counts as ctx.failed (via ctx.recordFailure), so FailFast's existing stop-at-the-next-check
 // logic naturally stops the remaining specs in the group — but after still runs regardless, via defer.

--- a/specs/runner_recovery_test.go
+++ b/specs/runner_recovery_test.go
@@ -1,0 +1,200 @@
+package specs
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestRunGroupSpecPanicRecoveredSiblingsStillRun proves a panicking spec doesn't stop its siblings
+// in the same group from running — matching the default execution path's contract.
+func TestRunGroupSpecPanicRecoveredSiblingsStillRun(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var ranSpec2 bool
+	g := &group{
+		specs: []step{
+			func(*Context) { panic("boom") },
+			func(*Context) { ranSpec2 = true },
+		},
+	}
+	runGroup(ctx, g)
+
+	if !ranSpec2 {
+		t.Fatal("expected spec2 to run after spec1 panicked, but it didn't")
+	}
+	if len(backend.errors) != 1 || !strings.Contains(backend.errors[0], "boom") {
+		t.Fatalf("expected exactly one recorded failure mentioning the panic message, got %v", backend.errors)
+	}
+}
+
+// TestRunGroupAfterAlwaysRunsDespiteSpecPanic proves the group's after hooks still run when a spec
+// panics, matching #61's runProgram contract for the default execution path.
+func TestRunGroupAfterAlwaysRunsDespiteSpecPanic(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var afterRan bool
+	g := &group{
+		specs: []step{func(*Context) { panic("boom") }},
+		after: []step{func(*Context) { afterRan = true }},
+	}
+	runGroup(ctx, g)
+
+	if !afterRan {
+		t.Fatal("expected the group's after hook to run despite the spec panic")
+	}
+	if !ctx.failed {
+		t.Fatal("expected ctx.failed to be set after an unrecovered spec panic")
+	}
+}
+
+// TestRunGroupBeforePanicSkipsSpecsButRunsAfter proves the contract decided for #62: a panic in a
+// before hook stops the rest of setup and skips this group's specs entirely (they can't be trusted
+// to run against setup that never completed), but the group's after still runs.
+func TestRunGroupBeforePanicSkipsSpecsButRunsAfter(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var specRan, afterRan bool
+	g := &group{
+		before: []step{func(*Context) { panic("setup boom") }},
+		specs:  []step{func(*Context) { specRan = true }},
+		after:  []step{func(*Context) { afterRan = true }},
+	}
+	runGroup(ctx, g)
+
+	if specRan {
+		t.Fatal("expected specs to be skipped after a before-hook panic, but a spec ran")
+	}
+	if !afterRan {
+		t.Fatal("expected the group's after hook to still run after a before-hook panic")
+	}
+	if len(backend.errors) != 1 || !strings.Contains(backend.errors[0], "setup boom") {
+		t.Fatalf("expected exactly one recorded failure mentioning the panic message, got %v", backend.errors)
+	}
+}
+
+// TestRunGroupAfterHookPanicDoesNotStopSiblingAfterHooks proves one panicking after hook doesn't
+// prevent the remaining after hooks (for the same group) from running.
+func TestRunGroupAfterHookPanicDoesNotStopSiblingAfterHooks(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var secondRan bool
+	// after runs in reverse order (index len-1 down to 0), so the second element here runs first.
+	g := &group{
+		specs: []step{func(*Context) {}},
+		after: []step{
+			func(*Context) { secondRan = true },
+			func(*Context) { panic("after boom") },
+		},
+	}
+	runGroup(ctx, g)
+
+	if !secondRan {
+		t.Fatal("expected the sibling after hook to run despite the first-executed one panicking")
+	}
+	found := false
+	for _, e := range backend.errors {
+		if strings.Contains(e, "after boom") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected the after-hook panic to be recorded as a failure, got %v", backend.errors)
+	}
+}
+
+// TestRunGroupFailFastStopsRemainingSpecsButAfterStillRuns proves the contract decided for #62: a
+// panic counts as ctx.failed (via ctx.recordFailure), so FailFast's existing stop-at-the-next-check
+// logic naturally stops the remaining specs in the group — but after still runs regardless, via defer.
+func TestRunGroupFailFastStopsRemainingSpecsButAfterStillRuns(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	ctx.SetFailFast(true)
+	var ranSpec2, afterRan bool
+	g := &group{
+		specs: []step{
+			func(*Context) { panic("boom") },
+			func(*Context) { ranSpec2 = true },
+		},
+		after: []step{func(*Context) { afterRan = true }},
+	}
+	runGroup(ctx, g)
+
+	if ranSpec2 {
+		t.Fatal("expected FailFast to stop the remaining specs in the group after a panic")
+	}
+	if !afterRan {
+		t.Fatal("expected the group's after hook to still run under FailFast")
+	}
+}
+
+// TestRunGroupsContinuesToNextGroupAfterPanic proves issue #15's core requirement at the group-
+// iteration level: a spec that panics in one group is recorded as that group's failure, and the
+// next group still runs — the process doesn't crash and other groups' results aren't discarded.
+func TestRunGroupsContinuesToNextGroupAfterPanic(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var ranGroup1 bool
+	groups := []group{
+		{specs: []step{func(*Context) { panic("boom") }}},
+		{specs: []step{func(*Context) { ranGroup1 = true }}},
+	}
+	runGroups(ctx, groups)
+
+	if !ranGroup1 {
+		t.Fatal("expected the second group to still run after the first group's spec panicked")
+	}
+	if len(backend.errors) != 1 || !strings.Contains(backend.errors[0], "boom") {
+		t.Fatalf("expected exactly one recorded failure mentioning the panic message, got %v", backend.errors)
+	}
+}
+
+// TestRunGroupsFailFastStopsSubsequentGroupsAfterPanic proves a panic interacts with FailFast the
+// same way an ordinary assertion failure does: it stops progression to the next group.
+func TestRunGroupsFailFastStopsSubsequentGroupsAfterPanic(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	ctx.SetFailFast(true)
+	var ranGroup1 bool
+	groups := []group{
+		{specs: []step{func(*Context) { panic("boom") }}},
+		{specs: []step{func(*Context) { ranGroup1 = true }}},
+	}
+	runGroups(ctx, groups)
+
+	if ranGroup1 {
+		t.Fatal("expected FailFast to stop the second group from running after the first group's panic")
+	}
+}
+
+// TestRunnerRunRecoversPanicAcrossGroupsRealProcess is a thin end-to-end check that Runner.Run —
+// the public entry point, with the real contextPool/testBackend wiring, not the internal helpers
+// exercised above — turns a panicking spec into an ordinary test failure instead of crashing the
+// process. Runs in a subprocess (same pattern as TestGeneratedFatalUsesRealSubtestBoundary in
+// execution_plan_test.go) rather than a nested t.Run, since a nested subtest's real Errorf would
+// itself mark this test failed; a subprocess crash, by contrast, would simply never print "group1
+// ran" at all — the clearest possible proof the process kept going.
+func TestRunnerRunRecoversPanicAcrossGroupsRealProcess(t *testing.T) {
+	if os.Getenv("GO_SPECS_RUNNER_PANIC_HELPER") == "1" {
+		prog := &Program{
+			Groups: []group{
+				{specs: []step{func(*Context) { panic("boom") }}},
+				{specs: []step{func(*Context) { fmt.Println("group1 ran") }}},
+			},
+		}
+		NewRunner(prog).Run(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunnerRunRecoversPanicAcrossGroupsRealProcess$")
+	cmd.Env = append(os.Environ(), "GO_SPECS_RUNNER_PANIC_HELPER=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the panicking spec to fail the test, but it passed: %s", output)
+	}
+	if !strings.Contains(string(output), "group1 ran") {
+		t.Fatalf("expected the second group to still run (process must not crash), got: %s", output)
+	}
+}


### PR DESCRIPTION
## Problem

`Runner.Run` (specs/runner.go) — the grouped `before`/`specs`/`after` backend used by the `Describe`/`BeforeEach`/`It` DSL — ran every hook and spec with no `recover()`. A panic anywhere in the loop crashed the whole test binary, discarding the results of every subsequent group in the program. Part of #15; this PR covers the grouped-hooks backend specifically (fixes #62).

## Contract decision (agreed before implementation)

Unlike `execution_plan.go` (#61), a `group` here shares **one** `before` slice and **one** `after` slice across all of its `specs` (see program.go's header on this perf optimization for large suites). That structural difference means "does the next thing still run after a panic" isn't a single answer — it depends on whether the panic was in `before`, a spec, or `after`. Agreed contract:

1. **A panicking spec doesn't stop its siblings.** Each spec in `g.specs` is recovered individually, matching the default execution path's contract from #61.
2. **Panic recovery reuses the existing `FailFast`/`ctx.failed` machinery** (via `ctx.recordFailure()`) rather than introducing new panic-specific abort state. `FailFast` already breaks the loop at group/spec boundaries once `ctx.failed` is true — recovering a panic by calling `recordFailure()` makes it behave exactly like a recorded assertion failure for that purpose, no separate code path needed.
3. **A panicking `before` hook skips this group's specs** (they can't be trusted to run meaningfully against setup that never completed) **but `after` always still runs**, via `defer`, so any partial setup gets a chance at cleanup.

`parallelStep` (program.go) needed no changes — it already fully recovers panics per-goroutine before any result reaches `Runner.Run`'s loop (confirmed by grep: it's the only `parallelBackend{}` construction site), so `parallelAbort{}` can't escape into this loop, same finding as #61.

## Current semantics preserved

- `FailFast` checks remain at every boundary (before-hook loop, before→specs, spec loop, specs→after, after-hook loop) — recovered panics participate in `FailFast` exactly like assertion failures always did.
- `after` hooks still run in reverse order (LIFO).
- Moving `after` into a `defer` means it also now runs if a spec calls a real `t.Fatal`/`FailNow` (`runtime.Goexit()` unwinds through the defer) — previously such a call would skip `after` entirely if it happened mid-`specs` loop with `FailFast` off, since the goroutine would just exit. This is a strict improvement (cleanup no longer silently skipped) and mirrors the same side effect already reviewed and approved for #61.

## Fix

Decomposed the flat loop into testable helpers: `runGroups`, `runGroup`, `runBeforeRecovered`, `runSpecsRecovered`, `runAfterRecovered`, `runStepRecovered`. Each step is wrapped in its own `recover()`; a caught panic is recorded via `ctx.recordFailure()` and reported via `ctx.backend.Errorf(...)` with the panic value and a stack trace (`runtime/debug.Stack()`) — same shape as #61.

## Tests

New `specs/runner_recovery_test.go`, 8 tests:
- Spec panic recovered; siblings in the same group still run.
- `after` always runs despite a spec panic.
- `before` panic skips this group's specs but `after` still runs.
- An `after`-hook panic doesn't stop sibling `after` hooks.
- `FailFast` stops remaining specs after a panic, but `after` still runs.
- A panic in one group doesn't stop the next group from running.
- `FailFast` does stop subsequent groups after a panic.
- End-to-end proof through the real `Runner.Run(tb testing.TB)` entry point, in a subprocess (mirrors `execution_plan_test.go`'s `TestGeneratedFatalUsesRealSubtestBoundary` pattern — avoids polluting the outer test's pass/fail via a nested `t.Run` on a real backend).

Most tests use the new `runGroups`/`runGroup` helpers directly with `controlledBackend`, avoiding a real `testing.TB` (matches the existing convention in `execution_plan_test.go`).

## Proof of the pre-fix bug

Stashed the fix and reran a minimal reproduction against the original loop: a panicking spec in group 1 crashed the entire `go test` process before group 2 ever ran —

```
panic: boom [recovered, repanicked]
```

Confirms this is the same class of bug fixed for the default execution path in #61, now closed for the grouped-hooks backend too.

## Validation

- `gofmt -l` — clean
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — clean, no failures
- `go test ./... -race -count=2` — clean
- `make build` — clean
- `make lint` — 0 issues

## Relationship

Fixes #62. Part of #15 — #15 stays open until every execution backend is covered. `MinimalRunner` (#63), `BytecodeRunner` (#64), and `BlockRunner` (#65) remain.
