### PR TITLE
fix(specs): recover panics in BlockRunner.Run

### DIFF
--- a/specs/block_runner.go
+++ b/specs/block_runner.go
@@ -3,7 +3,10 @@
 // instead of per spec, reducing loop overhead. No allocations during execution.
 package specs
 
-import "testing"
+import (
+	"runtime/debug"
+	"testing"
+)
 
 // DefaultBlockSize is the default number of specs per block when blockSize <= 0.
 const DefaultBlockSize = 8
@@ -54,6 +57,10 @@ func NewBlockRunner(fns []func(*Context), blocks []specBlock) *BlockRunner {
 
 // Run executes all blocks in order; each block runs its specs sequentially. One context
 // from the pool, reused for every spec. No allocations in the loop.
+//
+// A panic in a spec is recovered instead of crashing the process: it's recorded as a failure
+// (via ctx.recordFailure + ctx.backend.Errorf, message and stack trace), and the next spec in the
+// block, and the next block, still run.
 func (r *BlockRunner) Run(tb testing.TB) {
 	if r == nil || tb == nil || len(r.blocks) == 0 {
 		return
@@ -68,16 +75,33 @@ func (r *BlockRunner) Run(tb testing.TB) {
 	ctx.Reset(backend)
 	ctx.SetPathValues(PathValues{})
 
-	fns := r.fns
-	blocks := r.blocks
+	runBlocks(ctx, r.fns, r.blocks)
+}
+
+// runBlocks runs every block's specs sequentially against ctx, recovering each spec individually.
+// Split out from Run so it can be tested without a real testing.TB.
+func runBlocks(ctx *Context, fns []func(*Context), blocks []specBlock) {
 	for bi := 0; bi < len(blocks); bi++ {
 		b := blocks[bi]
 		blockFns := fns[b.start : b.start+b.count]
 		n := len(blockFns)
 		for i := 0; i < n; i++ {
-			blockFns[i](ctx)
+			runBlockSpecRecovered(ctx, blockFns[i])
 		}
 	}
+}
+
+// runBlockSpecRecovered runs a single spec, recovering a panic so it fails just this spec instead
+// of crashing the process. isExpectedAbort sentinels (a controlled backend's FailNow) are already
+// recorded by the backend and must not be reported a second time.
+func runBlockSpecRecovered(ctx *Context, fn func(*Context)) {
+	defer func() {
+		if recovered := recover(); recovered != nil && !isExpectedAbort(recovered) {
+			ctx.recordFailure()
+			ctx.backend.Errorf("panic: %v\n%s", recovered, debug.Stack())
+		}
+	}()
+	fn(ctx)
 }
 
 // NumSpecs returns the total number of specs (sum of all block counts).

--- a/specs/block_runner_recovery_test.go
+++ b/specs/block_runner_recovery_test.go
@@ -1,0 +1,110 @@
+package specs
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestRunBlocksRecoversPanicSiblingsStillRun proves issue #15's core requirement for BlockRunner: a
+// panicking spec is recorded as a failure instead of crashing the process, and the next spec in the
+// same block still runs.
+func TestRunBlocksRecoversPanicSiblingsStillRun(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var ranSpec2 bool
+	fns := []func(*Context){
+		func(*Context) { panic("boom") },
+		func(*Context) { ranSpec2 = true },
+	}
+	blocks := []specBlock{{start: 0, count: 2}}
+	runBlocks(ctx, fns, blocks)
+
+	if !ranSpec2 {
+		t.Fatal("expected the second spec in the block to run after the first one panicked")
+	}
+	if len(backend.errors) != 1 || !strings.Contains(backend.errors[0], "boom") {
+		t.Fatalf("expected exactly one recorded failure mentioning the panic message, got %v", backend.errors)
+	}
+}
+
+// TestRunBlocksContinuesToNextBlockAfterPanic proves a panic in one block doesn't stop the next
+// block from running — no results are discarded.
+func TestRunBlocksContinuesToNextBlockAfterPanic(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var ranBlock2 bool
+	fns := []func(*Context){
+		func(*Context) { panic("boom") },
+		func(*Context) { ranBlock2 = true },
+	}
+	blocks := []specBlock{{start: 0, count: 1}, {start: 1, count: 1}}
+	runBlocks(ctx, fns, blocks)
+
+	if !ranBlock2 {
+		t.Fatal("expected the second block to still run after the first block's spec panicked")
+	}
+	if len(backend.errors) != 1 || !strings.Contains(backend.errors[0], "boom") {
+		t.Fatalf("expected exactly one recorded failure mentioning the panic message, got %v", backend.errors)
+	}
+}
+
+// TestRunBlocksDoesNotDoubleReportExpectedAbort proves that a controlled backend's FailNow sentinel
+// is not double-reported as an unexpected panic (mirrors the same check already made for the default
+// execution path and Runner.Run).
+func TestRunBlocksDoesNotDoubleReportExpectedAbort(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var ranSpec2 bool
+	fns := []func(*Context){
+		func(c *Context) { c.backend.FailNow() },
+		func(*Context) { ranSpec2 = true },
+	}
+	blocks := []specBlock{{start: 0, count: 2}}
+	runBlocks(ctx, fns, blocks)
+
+	if !backend.failNow {
+		t.Fatal("expected the backend to have recorded FailNow")
+	}
+	if !ranSpec2 {
+		t.Fatal("expected the second spec to still run after the expected-abort sentinel")
+	}
+	if len(backend.errors) != 0 {
+		t.Fatalf("expected no unexpected-panic error for an expected abort sentinel, got %v", backend.errors)
+	}
+}
+
+// TestBlockRunnerRunRecoversPanicRealProcess proves the fix end-to-end through the real public
+// BlockRunner.Run(tb testing.TB) entry point, using a subprocess so the intentional panic/failure
+// doesn't mark this test itself as failed (mirrors execution_plan_test.go's subprocess pattern).
+func TestBlockRunnerRunRecoversPanicRealProcess(t *testing.T) {
+	if os.Getenv("BLOCK_RUNNER_RECOVERY_SUBPROCESS") == "1" {
+		var ranSpec2 bool
+		specs := []RunSpec{
+			{Name: "s1", Fn: func(*Context) { panic("boom") }},
+			{Name: "s2", Fn: func(*Context) { ranSpec2 = true }},
+		}
+		fns, blocks := CompileBlocks(specs, 8)
+		r := NewBlockRunner(fns, blocks)
+		r.Run(t)
+		if ranSpec2 {
+			fmt.Println("spec2 ran")
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestBlockRunnerRunRecoversPanicRealProcess")
+	cmd.Env = append(os.Environ(), "BLOCK_RUNNER_RECOVERY_SUBPROCESS=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the subprocess test to fail (panic recorded via t.Errorf), but it passed:\n%s", out)
+	}
+	if !strings.Contains(string(out), "spec2 ran") {
+		t.Fatalf("expected spec2 to still run after spec1 panicked, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "boom") {
+		t.Fatalf("expected the panic message in the subprocess output, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Problem

`BlockRunner.Run` (specs/block_runner.go) ran each block's specs sequentially with no `recover()`. A panic in any spec crashed the whole test binary. `BlockRunner` has no hooks and no parallel counterpart — the simplest of the remaining backends. Part of #15, fixes #65.

## Current semantics

Blocks are just index ranges into a shared `fns` slice; execution is a flat double loop over blocks then specs within each block. No before/after hooks, no `FailFast` field — nothing to decide beyond "recover per spec, keep going."

## Fix

Extracted `runBlocks(ctx, fns, blocks)` from `Run` (mirrors `execution_plan.go`'s `runProgram` split, so it's testable without a real `testing.TB`) and `runBlockSpecRecovered`, which wraps each spec in its own `recover()`. A caught panic is recorded via `ctx.recordFailure()` + `ctx.backend.Errorf(...)` (message + stack trace via `runtime/debug.Stack()`), same shape as #61/#62. Reused the existing `isExpectedAbort` sentinel check from `execution_plan.go` so a controlled backend's `FailNow` isn't double-reported as an unexpected panic.

## Tests

New `specs/block_runner_recovery_test.go`, 4 tests:
- A panicking spec is recorded; the next spec in the same block still runs.
- A panic in one block doesn't stop the next block from running.
- `isExpectedAbort` sentinel (`FailNow`) is not double-reported.
- End-to-end proof through the real `BlockRunner.Run(tb testing.TB)` entry point, in a subprocess (same pattern as #61/#62 — avoids polluting the outer test's pass/fail).

## Proof of the pre-fix bug

Stashed the fix, ran a minimal reproduction: a panicking spec in block 1 crashed the entire `go test` process before block 2 ever ran — `panic: boom [recovered, repanicked]`.

## Validation

- `gofmt -l` — clean
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — clean
- `go test ./... -race -count=2` — clean
- `make build` — clean
- `make lint` — 0 issues

## Relationship

Fixes #65. Part of #15 — #15 stays open until every execution backend is covered. `MinimalRunner` (#63) and `BytecodeRunner` (#64) remain.
