### PR TITLE
fix(specs): recover panics in MinimalRunner.Run (sequential path)

### DIFF
--- a/specs/minimal_runner.go
+++ b/specs/minimal_runner.go
@@ -9,6 +9,7 @@ package specs
 
 import (
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"testing"
 )
@@ -62,6 +63,10 @@ const RunBatchSize = 8
 
 // Run executes all specs in order. One context from pool, reused for every spec; zero allocs in loop.
 // Specs are run in batches of RunBatchSize to improve cache behavior and reduce loop overhead.
+//
+// A panic in a spec is recovered instead of crashing the process: it's recorded as a failure (via
+// ctx.recordFailure + ctx.backend.Errorf, message and stack trace), and the next spec still runs —
+// same contract as BlockRunner.Run and the default execution path.
 func (r *MinimalRunner) Run(tb testing.TB) {
 	if r == nil || tb == nil || len(r.specs) == 0 {
 		return
@@ -76,14 +81,32 @@ func (r *MinimalRunner) Run(tb testing.TB) {
 	ctx.Reset(backend)
 	ctx.SetPathValues(PathValues{})
 
-	specs := r.specs
+	runMinimalSpecs(ctx, r.specs)
+}
+
+// runMinimalSpecs runs every spec sequentially against ctx, recovering each one individually. Split
+// out from Run so it can be tested without a real testing.TB.
+func runMinimalSpecs(ctx *Context, specs []RunSpec) {
 	n := len(specs)
 	for i := 0; i < n; i += RunBatchSize {
 		end := min(i+RunBatchSize, n)
 		for j := i; j < end; j++ {
-			specs[j].Fn(ctx)
+			runMinimalSpecRecovered(ctx, specs[j].Fn)
 		}
 	}
+}
+
+// runMinimalSpecRecovered runs a single spec, recovering a panic so it fails just this spec instead
+// of crashing the process. isExpectedAbort sentinels (a controlled backend's FailNow) are already
+// recorded by the backend and must not be reported a second time.
+func runMinimalSpecRecovered(ctx *Context, fn func(*Context)) {
+	defer func() {
+		if recovered := recover(); recovered != nil && !isExpectedAbort(recovered) {
+			ctx.recordFailure()
+			ctx.backend.Errorf("panic: %v\n%s", recovered, debug.Stack())
+		}
+	}()
+	fn(ctx)
 }
 
 // RunParallel runs specs across workers goroutines. Each worker reuses one Context from contextPool.

--- a/specs/minimal_runner_recovery_test.go
+++ b/specs/minimal_runner_recovery_test.go
@@ -1,0 +1,170 @@
+package specs
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestRunMinimalSpecsRecoversPanicSiblingsStillRun proves issue #15's core requirement for
+// MinimalRunner.Run: a panicking spec is recorded as a failure instead of crashing the process, and
+// the next spec in the same batch still runs.
+func TestRunMinimalSpecsRecoversPanicSiblingsStillRun(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var ranSpec2 bool
+	specs := []RunSpec{
+		{Name: "s1", Fn: func(*Context) { panic("boom") }},
+		{Name: "s2", Fn: func(*Context) { ranSpec2 = true }},
+	}
+	runMinimalSpecs(ctx, specs)
+
+	if !ranSpec2 {
+		t.Fatal("expected the second spec to run after the first one panicked")
+	}
+	if len(backend.errors) != 1 || !strings.Contains(backend.errors[0], "boom") {
+		t.Fatalf("expected exactly one recorded failure mentioning the panic message, got %v", backend.errors)
+	}
+}
+
+// TestRunMinimalSpecsRecoversPanicAcrossBatchBoundary proves a panic in one RunBatchSize batch
+// doesn't stop the next batch from running — no results are discarded across the batching boundary.
+func TestRunMinimalSpecsRecoversPanicAcrossBatchBoundary(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	n := RunBatchSize + 1
+	specs := make([]RunSpec, n)
+	specs[0] = RunSpec{Name: "s0", Fn: func(*Context) { panic("boom") }}
+	var ranLast bool
+	for i := 1; i < n-1; i++ {
+		specs[i] = RunSpec{Name: "s", Fn: func(*Context) {}}
+	}
+	specs[n-1] = RunSpec{Name: "last", Fn: func(*Context) { ranLast = true }}
+	runMinimalSpecs(ctx, specs)
+
+	if !ranLast {
+		t.Fatal("expected the spec in the next batch to still run after the first batch's spec panicked")
+	}
+	if len(backend.errors) != 1 || !strings.Contains(backend.errors[0], "boom") {
+		t.Fatalf("expected exactly one recorded failure mentioning the panic message, got %v", backend.errors)
+	}
+}
+
+// TestRunMinimalSpecsDoesNotDoubleReportExpectedAbort proves that a controlled backend's FailNow
+// sentinel is not double-reported as an unexpected panic.
+func TestRunMinimalSpecsDoesNotDoubleReportExpectedAbort(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var ranSpec2 bool
+	specs := []RunSpec{
+		{Name: "s1", Fn: func(c *Context) { c.backend.FailNow() }},
+		{Name: "s2", Fn: func(*Context) { ranSpec2 = true }},
+	}
+	runMinimalSpecs(ctx, specs)
+
+	if !backend.failNow {
+		t.Fatal("expected the backend to have recorded FailNow")
+	}
+	if !ranSpec2 {
+		t.Fatal("expected the second spec to still run after the expected-abort sentinel")
+	}
+	if len(backend.errors) != 0 {
+		t.Fatalf("expected no unexpected-panic error for an expected abort sentinel, got %v", backend.errors)
+	}
+}
+
+// TestMinimalRunnerRunRecoversPanicRealProcess proves the fix end-to-end through the real public
+// MinimalRunner.Run(tb testing.TB) entry point, in a subprocess (mirrors the pattern already used for
+// #61/#62/#65 — avoids polluting the outer test's pass/fail via the real backend's Errorf).
+func TestMinimalRunnerRunRecoversPanicRealProcess(t *testing.T) {
+	if os.Getenv("MINIMAL_RUNNER_RECOVERY_SUBPROCESS") == "1" {
+		var ranSpec2 bool
+		r := NewMinimalRunner(2)
+		r.Add("s1", func(*Context) { panic("boom") })
+		r.Add("s2", func(*Context) { ranSpec2 = true })
+		r.Run(t)
+		if ranSpec2 {
+			fmt.Println("spec2 ran")
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestMinimalRunnerRunRecoversPanicRealProcess")
+	cmd.Env = append(os.Environ(), "MINIMAL_RUNNER_RECOVERY_SUBPROCESS=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the subprocess test to fail (panic recorded via t.Errorf), but it passed:\n%s", out)
+	}
+	if !strings.Contains(string(out), "spec2 ran") {
+		t.Fatalf("expected spec2 to still run after spec1 panicked, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "boom") {
+		t.Fatalf("expected the panic message in the subprocess output, got:\n%s", out)
+	}
+}
+
+// TestMinimalRunnerRunParallelAlreadyRecoversPanic confirms RunParallel (via scheduler.go's
+// runWorker/runWorkerSpec, unchanged by this fix) isolates a panic to the panicking spec's result:
+// sibling specs across workers still complete and the process doesn't crash. Documents that the
+// parallel path was already safe before this fix — only the sequential Run needed one.
+func TestMinimalRunnerRunParallelAlreadyRecoversPanic(t *testing.T) {
+	const n = 20
+	r := NewMinimalRunner(n)
+	var mu sync.Mutex
+	ran := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		i := i
+		r.Add("s", func(*Context) {
+			if i == 5 {
+				panic("boom")
+			}
+			mu.Lock()
+			ran[i] = true
+			mu.Unlock()
+		})
+	}
+	var reported string
+	reporter := &fakeReporter{fatalf: func(format string, args ...any) { reported = fmt.Sprintf(format, args...) }}
+	r.RunParallel(reporter, 4)
+
+	if len(ran) != n-1 {
+		t.Fatalf("expected %d specs to complete despite one panicking, got %d", n-1, len(ran))
+	}
+	if !strings.Contains(reported, "boom") {
+		t.Fatalf("expected the panicking spec to be reported as a failure, got %q", reported)
+	}
+}
+
+// TestMinimalRunnerRunParallelBatchedAlreadyRecoversPanic is the RunParallelBatched analogue of
+// TestMinimalRunnerRunParallelAlreadyRecoversPanic (via scheduler_batch.go's runWorkerBatched, which
+// also delegates to runWorkerSpec).
+func TestMinimalRunnerRunParallelBatchedAlreadyRecoversPanic(t *testing.T) {
+	const n = 20
+	r := NewMinimalRunner(n)
+	var mu sync.Mutex
+	ran := make(map[int]bool)
+	for i := 0; i < n; i++ {
+		i := i
+		r.Add("s", func(*Context) {
+			if i == 5 {
+				panic("boom")
+			}
+			mu.Lock()
+			ran[i] = true
+			mu.Unlock()
+		})
+	}
+	var reported string
+	reporter := &fakeReporter{fatalf: func(format string, args ...any) { reported = fmt.Sprintf(format, args...) }}
+	r.RunParallelBatched(reporter, 4, 4)
+
+	if len(ran) != n-1 {
+		t.Fatalf("expected %d specs to complete despite one panicking, got %d", n-1, len(ran))
+	}
+	if !strings.Contains(reported, "boom") {
+		t.Fatalf("expected the panicking spec to be reported as a failure, got %q", reported)
+	}
+}


### PR DESCRIPTION
## Problem

`MinimalRunner.Run` (specs/minimal_runner.go) ran the sequential batched loop with no `recover()`. A panic in any spec crashed the whole test binary. Part of #15, fixes #63.

## Current semantics — sequential vs. parallel gap

`RunParallel` and `RunParallelBatched` were **already safe**: both dispatch to `scheduler.go`'s `runWorker`/`runWorkerBatched`, which call `runWorkerSpec` — that already recovers each spec individually, distinguishing the expected `parallelAbort{}` sentinel from a genuine panic (scheduler.go:118-135). Only the sequential `Run` had the gap. This is exactly the sequential/parallel inconsistency risk flagged when this issue was filed — fix one path, leave the other one covered by a different (already-correct) mechanism, and it's easy to assume the whole type is unsafe when only one path is.

`MinimalRunner` has no hooks and no `FailFast` field — same minimal shape as `BlockRunner` (#65).

## Fix

Extracted `runMinimalSpecs(ctx, specs)` from `Run` (mirrors the `execution_plan.go`/`block_runner.go` split, testable without a real `testing.TB`) and `runMinimalSpecRecovered`, which wraps each spec in its own `recover()`. A caught panic is recorded via `ctx.recordFailure()` + `ctx.backend.Errorf(...)` (message + stack trace), and reuses `isExpectedAbort` so a controlled backend's `FailNow` isn't double-reported — same pattern as #65. Batching (`RunBatchSize`) is preserved; recovery happens per spec inside the inner batch loop, so a panic doesn't skip the rest of its batch or stop the next one.

`RunParallel`/`RunParallelBatched`/`scheduler.go` are unchanged — already correct.

## Tests

New `specs/minimal_runner_recovery_test.go`, 6 tests:
- Sequential: a panicking spec is recorded; the next spec in the same batch still runs.
- Sequential: a panic in one `RunBatchSize` batch doesn't stop the next batch.
- Sequential: `isExpectedAbort` sentinel (`FailNow`) is not double-reported.
- Sequential: end-to-end proof through the real `MinimalRunner.Run(tb testing.TB)`, in a subprocess (same pattern as #61/#62/#65).
- `RunParallel`: confirms panic isolation to the panicking spec — siblings across all workers still complete, no crash. Documents this path was already safe.
- `RunParallelBatched`: same confirmation for the batched worker path.

## Proof of the pre-fix bug

Stashed the fix, ran a minimal reproduction: a panicking spec crashed the entire `go test` process before the second spec ever ran — `panic: boom [recovered, repanicked]`.

## Validation

- `gofmt -l` — clean
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — clean
- `go test ./... -race -count=2` — clean
- `make build` — clean
- `make lint` — 0 issues

## Relationship

Fixes #63. Part of #15 — #15 stays open until every execution backend is covered. `BytecodeRunner` (#64) remains; after that, a final pass over #15's original text to confirm `scheduler.runWorker` is indeed already covered (it is — see "Current semantics" above) rather than needing its own issue.
