### PR TITLE
fix(specs): recover panics in BytecodeRunner.Run and RunParallel

### DIFF
--- a/specs/runner_bytecode.go
+++ b/specs/runner_bytecode.go
@@ -6,7 +6,9 @@
 package specs
 
 import (
+	"fmt"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,8 +24,12 @@ func NewBytecodeRunner(p BCProgram) *BytecodeRunner {
 	return &BytecodeRunner{program: p}
 }
 
-// Run executes all instructions in order. One context from the pool, reused for every instruction.
-// No allocations in the loop; bounds-check elimination applies to the index loop.
+// Run executes all specs in order. One context from the pool, reused for every spec.
+//
+// A panic anywhere in one spec's instruction range is recovered instead of crashing the process:
+// it's recorded as a failure (via ctx.recordFailure + ctx.backend.Errorf, message and stack trace),
+// and the next spec still runs. Recovery is per spec, not per instruction, matching RunParallel's
+// granularity.
 func (r *BytecodeRunner) Run(tb testing.TB) {
 	if r == nil || tb == nil || r.program.BCLen() == 0 {
 		return
@@ -38,8 +44,29 @@ func (r *BytecodeRunner) Run(tb testing.TB) {
 	ctx.Reset(backend)
 	ctx.SetPathValues(PathValues{})
 
-	code := r.program.Code
-	for i := 0; i < len(code); i++ {
+	runBytecodeSequential(ctx, r.program.Code, r.program.SpecStarts)
+}
+
+// runBytecodeSequential runs every spec's instruction range in order against ctx, recovering each
+// spec as a whole unit. Split out from Run so it can be tested without a real testing.TB.
+func runBytecodeSequential(ctx *Context, code []instruction, starts []int) {
+	nSpecs := len(starts) - 1
+	for si := 0; si < nSpecs; si++ {
+		runBytecodeSpecRecovered(ctx, code, starts[si], starts[si+1])
+	}
+}
+
+// runBytecodeSpecRecovered runs one spec's instruction range, recovering a panic so it fails just
+// this spec instead of crashing the process. isExpectedAbort sentinels (a controlled backend's
+// FailNow) are already recorded by the backend and must not be reported a second time.
+func runBytecodeSpecRecovered(ctx *Context, code []instruction, start, end int) {
+	defer func() {
+		if recovered := recover(); recovered != nil && !isExpectedAbort(recovered) {
+			ctx.recordFailure()
+			ctx.backend.Errorf("panic: %v\n%s", recovered, debug.Stack())
+		}
+	}()
+	for i := start; i < end; i++ {
 		if code[i].fn != nil {
 			code[i].fn(ctx)
 		}
@@ -110,11 +137,29 @@ func runBytecodeWorker(code []instruction, starts []int, nSpecs int, backend *pa
 		backend.specIndex = si
 		ctx.Reset(backend)
 		ctx.SetPathValues(PathValues{})
-		for i := start; i < end; i++ {
-			if code[i].fn != nil {
-				code[i].fn(ctx)
+		runBytecodeWorkerSpec(code, start, end, ctx, results, si)
+		ctx.Reset(nil)
+	}
+}
+
+// runBytecodeWorkerSpec runs one spec's instruction range, recovering the parallelAbort{} sentinel a
+// fatal assertion panics with when backend.abortOnFatal is set — an expected stop, already recorded
+// in results[idx], not a failure to report. Any other panic is recorded as an ordinary spec failure
+// instead of crashing the worker goroutine — which, since this runs inside a spawned goroutine, would
+// otherwise crash the entire process. Mirrors scheduler.go's runWorkerSpec.
+func runBytecodeWorkerSpec(code []instruction, start, end int, ctx *Context, results *[]string, idx int) {
+	defer func() {
+		switch r := recover(); r {
+		case nil, parallelAbort{}:
+		default:
+			if (*results)[idx] == "" {
+				(*results)[idx] = fmt.Sprintf("panic: %v", r)
 			}
 		}
-		ctx.Reset(nil)
+	}()
+	for i := start; i < end; i++ {
+		if code[i].fn != nil {
+			code[i].fn(ctx)
+		}
 	}
 }

--- a/specs/runner_bytecode_recovery_test.go
+++ b/specs/runner_bytecode_recovery_test.go
@@ -1,0 +1,173 @@
+package specs
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestRunBytecodeSequentialRecoversPanicSiblingsStillRun proves issue #15's core requirement for
+// BytecodeRunner.Run: a panicking spec is recorded as a failure instead of crashing the process, and
+// the next spec still runs. Recovery is per spec, matching RunParallel's granularity.
+func TestRunBytecodeSequentialRecoversPanicSiblingsStillRun(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var ranSpec2 bool
+	b := NewBCBuilder(8)
+	b.AddSpec(func(*Context) { panic("boom") })
+	b.AddSpec(func(*Context) { ranSpec2 = true })
+	prog := b.BuildBC()
+	runBytecodeSequential(ctx, prog.Code, prog.SpecStarts)
+
+	if !ranSpec2 {
+		t.Fatal("expected the second spec to run after the first one panicked")
+	}
+	if len(backend.errors) != 1 || !strings.Contains(backend.errors[0], "boom") {
+		t.Fatalf("expected exactly one recorded failure mentioning the panic message, got %v", backend.errors)
+	}
+}
+
+// TestRunBytecodeSequentialPanicSkipsRestOfSpecRange proves recovery is per spec, not per
+// instruction: a panic partway through one spec's instruction range (e.g. in a before hook) skips
+// the rest of that spec's range but does not affect the next spec.
+func TestRunBytecodeSequentialPanicSkipsRestOfSpecRange(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var ranSpec1Body, ranSpec2 bool
+	b := NewBCBuilder(8)
+	b.AddBefore(func(*Context) { panic("boom") })
+	b.AddSpec(func(*Context) { ranSpec1Body = true })
+	prog := b.BuildBC()
+	b2 := NewBCBuilder(8)
+	b2.AddSpec(func(*Context) { ranSpec2 = true })
+	prog2 := b2.BuildBC()
+
+	// Concatenate the two programs into one, so we get a "before panics, body never runs" spec
+	// followed by an unrelated spec, all in one flat instruction stream.
+	code := append(append([]instruction{}, prog.Code...), prog2.Code...)
+	starts := []int{prog.SpecStarts[0], prog.SpecStarts[1], prog.SpecStarts[1] + prog2.SpecStarts[1]}
+	runBytecodeSequential(ctx, code, starts)
+
+	if ranSpec1Body {
+		t.Fatal("expected spec1's body to be skipped after its before hook panicked")
+	}
+	if !ranSpec2 {
+		t.Fatal("expected spec2 to still run after spec1's before hook panicked")
+	}
+	if len(backend.errors) != 1 || !strings.Contains(backend.errors[0], "boom") {
+		t.Fatalf("expected exactly one recorded failure mentioning the panic message, got %v", backend.errors)
+	}
+}
+
+// TestRunBytecodeSequentialDoesNotDoubleReportExpectedAbort proves that a controlled backend's
+// FailNow sentinel is not double-reported as an unexpected panic (mirrors the same check already
+// made for the default execution path, Runner.Run, and BlockRunner.Run).
+func TestRunBytecodeSequentialDoesNotDoubleReportExpectedAbort(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	var ranSpec2 bool
+	b := NewBCBuilder(8)
+	b.AddSpec(func(c *Context) { c.backend.FailNow() })
+	b.AddSpec(func(*Context) { ranSpec2 = true })
+	prog := b.BuildBC()
+	runBytecodeSequential(ctx, prog.Code, prog.SpecStarts)
+
+	if !backend.failNow {
+		t.Fatal("expected the backend to have recorded FailNow")
+	}
+	if !ranSpec2 {
+		t.Fatal("expected the second spec to still run after the expected-abort sentinel")
+	}
+	if len(backend.errors) != 0 {
+		t.Fatalf("expected no unexpected-panic error for an expected abort sentinel, got %v", backend.errors)
+	}
+}
+
+// TestBytecodeRunnerRunRecoversPanicRealProcess proves the fix end-to-end through the real public
+// BytecodeRunner.Run(tb testing.TB) entry point, using a subprocess so the intentional panic/failure
+// doesn't mark this test itself as failed (mirrors execution_plan_test.go's subprocess pattern).
+func TestBytecodeRunnerRunRecoversPanicRealProcess(t *testing.T) {
+	if os.Getenv("BYTECODE_RUNNER_RECOVERY_SUBPROCESS") == "1" {
+		var ranSpec2 bool
+		b := NewBCBuilder(8)
+		b.AddSpec(func(*Context) { panic("boom") })
+		b.AddSpec(func(*Context) { ranSpec2 = true })
+		prog := b.BuildBC()
+		r := NewBytecodeRunner(prog)
+		r.Run(t)
+		if ranSpec2 {
+			fmt.Println("spec2 ran")
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestBytecodeRunnerRunRecoversPanicRealProcess")
+	cmd.Env = append(os.Environ(), "BYTECODE_RUNNER_RECOVERY_SUBPROCESS=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the subprocess test to fail (panic recorded via t.Errorf), but it passed:\n%s", out)
+	}
+	if !strings.Contains(string(out), "spec2 ran") {
+		t.Fatalf("expected spec2 to still run after spec1 panicked, output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "boom") {
+		t.Fatalf("expected the panic message in the subprocess output, got:\n%s", out)
+	}
+}
+
+// TestBytecodeRunnerRunParallelRecoversPanicSiblingsStillRun proves the fix for RunParallel's more
+// severe gap: before this fix, a panic inside a worker goroutine crashed the entire process, taking
+// down every concurrently-running test, not just this one. Now it's recorded as that spec's failure
+// and every sibling spec (across all workers) still completes.
+func TestBytecodeRunnerRunParallelRecoversPanicSiblingsStillRun(t *testing.T) {
+	const n = 20
+	const panicIndex = 5
+	var completed [n]bool
+	b := NewBCBuilder(n)
+	for i := 0; i < n; i++ {
+		i := i
+		b.AddSpec(func(*Context) {
+			if i == panicIndex {
+				panic("boom")
+			}
+			completed[i] = true
+		})
+	}
+	prog := b.BuildBC()
+	runner := NewBytecodeRunner(prog)
+
+	var reported string
+	fake := &fakeReporter{fatalf: func(format string, args ...any) { reported = fmt.Sprintf(format, args...) }}
+	runner.RunParallel(fake, 4)
+
+	for i := 0; i < n; i++ {
+		if i == panicIndex {
+			continue
+		}
+		if !completed[i] {
+			t.Errorf("expected spec[%d] to complete, it did not", i)
+		}
+	}
+	if reported == "" || !strings.Contains(reported, "boom") {
+		t.Fatalf("expected the panic to be reported mentioning the panic message, got %q", reported)
+	}
+	if !strings.Contains(reported, fmt.Sprintf("spec[%d]", panicIndex)) {
+		t.Fatalf("expected the report to mention spec[%d], got %q", panicIndex, reported)
+	}
+}
+
+// TestBytecodeRunnerRunParallelDoesNotDoubleReportExpectedAbort proves parallelAbort{} (the sentinel
+// a fatal assertion panics with when abortOnFatal is set) is not double-reported as an unexpected
+// panic — mirrors scheduler.go's runWorkerSpec test coverage.
+func TestBytecodeRunnerRunParallelDoesNotDoubleReportExpectedAbort(t *testing.T) {
+	results := make([]string, 1)
+	backend := &parallelBackend{results: &results, specIndex: 0, abortOnFatal: true}
+	code := []instruction{{fn: func(c *Context) { c.backend.FailNow() }}}
+	runBytecodeWorkerSpec(code, 0, 1, &Context{backend: backend}, &results, 0)
+
+	if results[0] != "fail now" {
+		t.Fatalf("expected results[0] to be %q (recorded by FailNow before the abort panic), got %q", "fail now", results[0])
+	}
+}


### PR DESCRIPTION
## Problem

`BytecodeRunner.Run` (specs/runner_bytecode.go) ran the flat instruction loop with no `recover()`. `BytecodeRunner.RunParallel`'s worker (`runBytecodeWorker`) also had no `recover()` around its per-spec instruction range — the more severe gap, since an unrecovered panic inside a spawned goroutine crashes the **entire process**, taking down concurrently-running tests too, not just this suite. Part of #15, fixes #64.

## Current semantics — bytecode has no per-instruction "kind" tag

Unlike `Runner`/`ExecutionPlan`, a compiled `instruction` (`bytecode_impl.go`) is just `{fn func(*Context)}` — before/body/after hooks are flattened into one contiguous range per spec with no runtime tag distinguishing them. Issue #64 flagged this explicitly as an open decision: recover per spec (matching `RunParallel`'s existing granularity) or per instruction. Per-instruction recovery isn't possible here without adding metadata that doesn't exist today, and the issue's "Expected fix" section says so directly: recover per spec, same shape as `scheduler.go`'s `runWorkerSpec`. That's what's implemented — no design tradeoff left open.

`BCProgram.SpecStarts` is always populated with a trailing sentinel (`SpecStarts[NumSpecs()] == len(Code)`, guaranteed by `BCBuilder.BuildBC()`), so `Run` reuses it directly — no new boundary-derivation logic needed.

## Fix

- `Run`: extracted `runBytecodeSequential(ctx, code, starts)`, which iterates `SpecStarts` and recovers each spec's whole instruction range as a unit via `runBytecodeSpecRecovered`. A caught panic is recorded via `ctx.recordFailure()` + `ctx.backend.Errorf(...)` (message + stack trace), reusing `isExpectedAbort` so a controlled backend's `FailNow` isn't double-reported.
- `RunParallel`/`runBytecodeWorker`: extracted `runBytecodeWorkerSpec`, which wraps one spec's instruction range in a `recover()` mirroring `scheduler.go`'s `runWorkerSpec` exactly — `switch r := recover(); r { case nil, parallelAbort{}: default: results[idx] = "panic: ..." }`.

Note: `BytecodeRunner.RunParallel`'s `parallelBackend` instances don't set `abortOnFatal: true` (unlike `MinimalRunner.RunParallel`'s), so `parallelAbort{}` is never actually thrown from a real `FailNow`/`Fatal`/`Fatalf` in this backend today. Left as-is — issue #64's "Expected fix" only asks for the recover to mirror `runWorkerSpec`'s shape, not to change `abortOnFatal`; that's a separate, pre-existing asymmetry, not part of this panic-recovery fix.

## Tests

New `specs/runner_bytecode_recovery_test.go`, 6 tests:
- Sequential: a panicking spec is recorded; the next spec still runs.
- Sequential: a panic partway through one spec's range (in a before hook) skips the rest of that spec's range (the body never runs) but doesn't affect the next spec — proves recovery is per spec, not per instruction.
- Sequential: `isExpectedAbort` sentinel (`FailNow`) is not double-reported.
- Sequential: end-to-end proof through the real `BytecodeRunner.Run(tb testing.TB)`, in a subprocess (same pattern as #61/#62/#65/#63).
- `RunParallel`: a panicking spec is recorded as that spec's failure; every sibling spec across all workers still completes; the process doesn't crash.
- `RunParallel`: `parallelAbort{}` from a fatal assertion is not double-reported as an unexpected panic (direct unit test on `runBytecodeWorkerSpec`).

## Proof of the pre-fix bug

Stashed the fix, ran a minimal reproduction of the more severe gap: a panicking spec inside a `RunParallel` worker goroutine crashed the entire test process — `panic: boom`, unrecovered, `FAIL` with no test result, not even an attributable failure.

## Validation

- `gofmt -l` — clean
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — clean
- `go test ./... -race -count=2` — clean
- `make build` — clean
- `make lint` — 0 issues

## Relationship

Fixes #64. Part of #15 — this closes the last piece of #15's original evidence (see #64's own text: `scheduler.go`'s `runWorker` was already safe, so no separate follow-up issue is needed there). Once this merges, every execution backend named in #15 is covered; next step is a final sweep of #15's text to confirm it can be closed.
