### PR TITLE
PR #12-A: revive ExecutionPlan reporting

### DIFF
--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -256,9 +256,9 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep report
 				// then-retried or intermediate Explore candidates would misrepresent how many
 				// executions actually happened, how long the suite really took, and where a
 				// failure occurred.
-				reportSpecStarted(rep, name, path)
+				started := reportSpecStarted(rep, name, path)
 				result := runIsolatedCase(backend, program, candidate.Values)
-				reportSpecFinished(rep, name, path, result.Failed)
+				reportSpecFinished(rep, started, result.Failed)
 				return !result.Failed
 			},
 			AdmitFeedback: func(feedback proposalFeedback) {
@@ -273,9 +273,9 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep report
 	}()
 	ctx.Reset(backend)
 	ctx.SetPathValues(PathValues{})
-	reportSpecStarted(rep, name, path)
+	started := reportSpecStarted(rep, name, path)
 	runProgram(program, ctx, nil)
-	reportSpecFinished(rep, name, path, ctx.failed)
+	reportSpecFinished(rep, started, ctx.failed)
 	return proposalControllerResult{}
 }
 
@@ -297,21 +297,23 @@ func specEventPath(plan *ExecutionPlan, i int) []string {
 	return strings.Split(plan.FullNames[i], "/")
 }
 
-func reportSpecStarted(rep report.EventReporter, name string, path []string) {
+// reportSpecStarted emits SpecStarted and returns the event it sent, so reportSpecFinished can
+// reuse its Time — SpecResultEvent embeds SpecStartEvent, and that Time means when the spec
+// started, not when it finished.
+func reportSpecStarted(rep report.EventReporter, name string, path []string) report.SpecStartEvent {
 	if rep == nil {
-		return
+		return report.SpecStartEvent{}
 	}
-	rep.SpecStarted(report.SpecStartEvent{Name: name, Path: path, Time: time.Now()})
+	e := report.SpecStartEvent{Name: name, Path: path, Time: time.Now()}
+	rep.SpecStarted(e)
+	return e
 }
 
-func reportSpecFinished(rep report.EventReporter, name string, path []string, failed bool) {
+func reportSpecFinished(rep report.EventReporter, start report.SpecStartEvent, failed bool) {
 	if rep == nil {
 		return
 	}
-	rep.SpecFinished(report.SpecResultEvent{
-		SpecStartEvent: report.SpecStartEvent{Name: name, Path: path, Time: time.Now()},
-		Failed:         failed,
-	})
+	rep.SpecFinished(report.SpecResultEvent{SpecStartEvent: start, Failed: failed})
 }
 
 // runProgram executes one spec's instructions directly in the caller's goroutine (the default,

--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -3,7 +3,6 @@ package specs
 
 import (
 	"context"
-	"io"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -146,9 +145,11 @@ func collectAncestorIDs(arena *NodeArena, nodeID int) []int {
 
 // CompiledSuite holds the compiled plan and optional arena reference. Run executes the plan.
 type CompiledSuite struct {
-	Plan   *ExecutionPlan
-	Arena  *NodeArena
-	RootID int
+	Plan     *ExecutionPlan
+	Arena    *NodeArena
+	RootID   int
+	Name     string // suite name for SuiteStartEvent/SuiteEndEvent; falls back to the backend's name if empty
+	Reporter report.EventReporter
 }
 
 // Run executes all specs in the plan. Uses one context from the pool per spec (or per path iteration).
@@ -167,8 +168,43 @@ func (s *CompiledSuite) run(tb testing.TB, runCtx context.Context) []proposalCon
 	}
 	backend := asTestBackend(tb)
 	defer putTestBackend(backend)
-	rep := report.New(io.Discard)
-	return runPlanFlatNoSubtests(runCtx, backend, rep, s.Plan)
+
+	if s.Reporter == nil {
+		return runPlanFlatNoSubtests(runCtx, backend, nil, s.Plan)
+	}
+	// counter observes every SpecFinished event to total TotalSpecs/FailedSpecs for SuiteEndEvent:
+	// Paths() can execute a variable number of candidates per plan index, so the plan alone can't
+	// tell us the count up front.
+	counter := &specCounter{EventReporter: s.Reporter}
+	name := s.Name
+	if name == "" {
+		name = backend.Name()
+	}
+	s.Reporter.SuiteStarted(report.SuiteStartEvent{Name: name, Time: time.Now()})
+	results := runPlanFlatNoSubtests(runCtx, backend, counter, s.Plan)
+	s.Reporter.SuiteFinished(report.SuiteEndEvent{
+		Name:        name,
+		Time:        time.Now(),
+		TotalSpecs:  counter.total,
+		FailedSpecs: counter.failed,
+	})
+	return results
+}
+
+// specCounter decorates an EventReporter to tally executed/failed specs for the enclosing suite's
+// SuiteEndEvent, then forwards every event unchanged to the underlying reporter.
+type specCounter struct {
+	report.EventReporter
+	total  int
+	failed int
+}
+
+func (c *specCounter) SpecFinished(e report.SpecResultEvent) {
+	c.total++
+	if e.Failed {
+		c.failed++
+	}
+	c.EventReporter.SpecFinished(e)
 }
 
 func executionContext(tb testing.TB) (context.Context, context.CancelFunc) {
@@ -184,7 +220,7 @@ func executionContext(tb testing.TB) (context.Context, context.CancelFunc) {
 	return context.WithCancel(ctx)
 }
 
-func runPlanFlatNoSubtests(runCtx context.Context, backend testBackend, rep *report.Reporter, plan *ExecutionPlan) []proposalControllerResult {
+func runPlanFlatNoSubtests(runCtx context.Context, backend testBackend, rep report.EventReporter, plan *ExecutionPlan) []proposalControllerResult {
 	results := make([]proposalControllerResult, 0, len(plan.ProgramStart))
 	for i := 0; i < len(plan.ProgramStart); i++ {
 		results = append(results, runExecutionContext(runCtx, backend, rep, plan, i))
@@ -192,17 +228,19 @@ func runPlanFlatNoSubtests(runCtx context.Context, backend testBackend, rep *rep
 	return results
 }
 
-func runExecution(backend testBackend, rep *report.Reporter, plan *ExecutionPlan, i int) proposalControllerResult {
+func runExecution(backend testBackend, rep report.EventReporter, plan *ExecutionPlan, i int) proposalControllerResult {
 	return runExecutionContext(context.Background(), backend, rep, plan, i)
 }
 
-func runExecutionContext(runCtx context.Context, backend testBackend, rep *report.Reporter, plan *ExecutionPlan, i int) proposalControllerResult {
+func runExecutionContext(runCtx context.Context, backend testBackend, rep report.EventReporter, plan *ExecutionPlan, i int) proposalControllerResult {
 	start := plan.ProgramStart[i]
 	length := plan.ProgramLen[i]
 	if start+length > len(plan.Instructions) {
 		return proposalControllerResult{}
 	}
 	program := plan.Instructions[start : start+length]
+	name := specEventName(plan, i)
+	path := specEventPath(plan, i)
 	if i < len(plan.PathGens) && plan.PathGens[i] != nil {
 		gen := plan.PathGens[i]
 		seq := gen.sequence()
@@ -213,7 +251,15 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 			MaxRejections: maxRejections,
 			Propose:       seq.next,
 			Execute: func(candidate proposalCandidate) bool {
-				return !runIsolatedCase(backend, program, candidate.Values).Failed
+				// Every executed candidate is its own spec execution and reports its own
+				// SpecStarted/SpecFinished — not just the last accepted one. Hiding rejected-
+				// then-retried or intermediate Explore candidates would misrepresent how many
+				// executions actually happened, how long the suite really took, and where a
+				// failure occurred.
+				reportSpecStarted(rep, name, path)
+				result := runIsolatedCase(backend, program, candidate.Values)
+				reportSpecFinished(rep, name, path, result.Failed)
+				return !result.Failed
 			},
 			AdmitFeedback: func(feedback proposalFeedback) {
 				seq.admitFeedback(feedback.Candidate.Values, feedback.Passed)
@@ -227,8 +273,45 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep *repor
 	}()
 	ctx.Reset(backend)
 	ctx.SetPathValues(PathValues{})
+	reportSpecStarted(rep, name, path)
 	runProgram(program, ctx, nil)
+	reportSpecFinished(rep, name, path, ctx.failed)
 	return proposalControllerResult{}
+}
+
+// specEventName returns plan.Names[i], or "" for a plan built without per-spec metadata (e.g. a
+// hand-built ExecutionPlan in a test that only populates Instructions/ProgramStart/ProgramLen).
+func specEventName(plan *ExecutionPlan, i int) string {
+	if i < 0 || i >= len(plan.Names) {
+		return ""
+	}
+	return plan.Names[i]
+}
+
+// specEventPath splits plan.FullNames[i]'s slash-joined breadcrumb back into path segments for
+// SpecStartEvent.Path, or nil for a plan without per-spec metadata (see specEventName).
+func specEventPath(plan *ExecutionPlan, i int) []string {
+	if i < 0 || i >= len(plan.FullNames) || plan.FullNames[i] == "" {
+		return nil
+	}
+	return strings.Split(plan.FullNames[i], "/")
+}
+
+func reportSpecStarted(rep report.EventReporter, name string, path []string) {
+	if rep == nil {
+		return
+	}
+	rep.SpecStarted(report.SpecStartEvent{Name: name, Path: path, Time: time.Now()})
+}
+
+func reportSpecFinished(rep report.EventReporter, name string, path []string, failed bool) {
+	if rep == nil {
+		return
+	}
+	rep.SpecFinished(report.SpecResultEvent{
+		SpecStartEvent: report.SpecStartEvent{Name: name, Path: path, Time: time.Now()},
+		Failed:         failed,
+	})
 }
 
 // runProgram executes one spec's instructions directly in the caller's goroutine (the default,

--- a/specs/execution_plan_reporter_test.go
+++ b/specs/execution_plan_reporter_test.go
@@ -1,0 +1,185 @@
+package specs
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pablogore/go-specs/report"
+)
+
+// recordingReporter is a report.EventReporter test double that records every event it receives,
+// so tests can assert on structured event data instead of parsing formatted strings.
+type recordingReporter struct {
+	mu            sync.Mutex
+	suiteStarted  []report.SuiteStartEvent
+	suiteFinished []report.SuiteEndEvent
+	specStarted   []report.SpecStartEvent
+	specFinished  []report.SpecResultEvent
+}
+
+func (r *recordingReporter) SuiteStarted(e report.SuiteStartEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.suiteStarted = append(r.suiteStarted, e)
+}
+
+func (r *recordingReporter) SuiteFinished(e report.SuiteEndEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.suiteFinished = append(r.suiteFinished, e)
+}
+
+func (r *recordingReporter) SpecStarted(e report.SpecStartEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.specStarted = append(r.specStarted, e)
+}
+
+func (r *recordingReporter) SpecFinished(e report.SpecResultEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.specFinished = append(r.specFinished, e)
+}
+
+var _ report.EventReporter = (*recordingReporter)(nil)
+
+// TestDescribeWithReporterEmitsSuiteAndSpecEventsForFlatSpec proves the reporter stored on
+// Spec/CompiledSuite actually reaches execution now: a single flat (non-Paths) spec emits exactly
+// one SpecStarted/SpecFinished pair, wrapped by one SuiteStarted/SuiteFinished pair reporting the
+// real spec count.
+func TestDescribeWithReporterEmitsSuiteAndSpecEventsForFlatSpec(t *testing.T) {
+	rep := &recordingReporter{}
+	DescribeWithReporter(t, "FlatSuite", rep, func(s *Spec) {
+		s.It("passes", func(ctx *Context) {})
+	})
+
+	if len(rep.suiteStarted) != 1 || rep.suiteStarted[0].Name != "FlatSuite" {
+		t.Fatalf("expected one SuiteStarted for FlatSuite, got %+v", rep.suiteStarted)
+	}
+	if len(rep.specStarted) != 1 || rep.specStarted[0].Name != "passes" {
+		t.Fatalf("expected one SpecStarted for 'passes', got %+v", rep.specStarted)
+	}
+	if len(rep.specFinished) != 1 || rep.specFinished[0].Name != "passes" || rep.specFinished[0].Failed {
+		t.Fatalf("expected one passing SpecFinished for 'passes', got %+v", rep.specFinished)
+	}
+	if len(rep.suiteFinished) != 1 {
+		t.Fatalf("expected one SuiteFinished, got %+v", rep.suiteFinished)
+	}
+	end := rep.suiteFinished[0]
+	if end.Name != "FlatSuite" || end.TotalSpecs != 1 || end.FailedSpecs != 0 {
+		t.Fatalf("expected FlatSuite TotalSpecs=1 FailedSpecs=0, got %+v", end)
+	}
+}
+
+// TestDescribeWithReporterMarksFailedFlatSpec proves a failing flat spec is reported as failed both
+// on its own SpecFinished event and in the enclosing SuiteEndEvent's FailedSpecs count.
+//
+// The spec body calls ctx.recordFailure() directly (what the framework's own Expect(...) matchers
+// do internally on a failed assertion) instead of ctx.T.Errorf/Fatalf: recordFailure only flips
+// Context's internal failed flag, so it exercises the same Failed-tracking path a real assertion
+// failure would without also failing this test's own *testing.T — which a real t.Errorf on the
+// generated subtest would do, since subtest failures bubble up to the parent test.
+func TestDescribeWithReporterMarksFailedFlatSpec(t *testing.T) {
+	rep := &recordingReporter{}
+	DescribeWithReporter(t, "FailingFlatSuite", rep, func(s *Spec) {
+		s.It("fails", func(ctx *Context) { ctx.recordFailure() })
+	})
+
+	if len(rep.specFinished) != 1 || !rep.specFinished[0].Failed {
+		t.Fatalf("expected one failing SpecFinished, got %+v", rep.specFinished)
+	}
+	if len(rep.suiteFinished) != 1 || rep.suiteFinished[0].FailedSpecs != 1 {
+		t.Fatalf("expected FailedSpecs=1, got %+v", rep.suiteFinished)
+	}
+}
+
+// TestDescribeWithReporterEmitsEventsPerCartesianCandidate proves Paths() reports every executed
+// candidate as its own spec execution — not just a single event for the whole generated spec.
+// Hiding intermediate candidates would misrepresent how many executions actually happened.
+func TestDescribeWithReporterEmitsEventsPerCartesianCandidate(t *testing.T) {
+	rep := &recordingReporter{}
+	DescribeWithReporter(t, "CartesianSuite", rep, func(s *Spec) {
+		s.Paths(func(pb *PathBuilder) {
+			pb.Values("tier", []any{"basic", "pro"})
+		}).It("includes tier", func(ctx *Context) {})
+	})
+
+	if len(rep.specStarted) != 2 {
+		t.Fatalf("expected 2 SpecStarted events (one per combo), got %d: %+v", len(rep.specStarted), rep.specStarted)
+	}
+	if len(rep.specFinished) != 2 {
+		t.Fatalf("expected 2 SpecFinished events (one per combo), got %d: %+v", len(rep.specFinished), rep.specFinished)
+	}
+	for _, e := range rep.specFinished {
+		if e.Failed {
+			t.Fatalf("expected all combos to pass, got %+v", e)
+		}
+		if e.Name != "includes tier" {
+			t.Fatalf("expected event name 'includes tier', got %q", e.Name)
+		}
+	}
+	if len(rep.suiteFinished) != 1 || rep.suiteFinished[0].TotalSpecs != 2 || rep.suiteFinished[0].FailedSpecs != 0 {
+		t.Fatalf("expected TotalSpecs=2 FailedSpecs=0, got %+v", rep.suiteFinished)
+	}
+}
+
+// TestDescribeWithReporterEmitsEventsPerSampleCandidate proves Sample() reports one
+// SpecStarted/SpecFinished pair per sample drawn, matching Explore/Sample's "every attempt is a
+// real execution" semantics.
+func TestDescribeWithReporterEmitsEventsPerSampleCandidate(t *testing.T) {
+	const samples = 4
+	rep := &recordingReporter{}
+	DescribeWithReporter(t, "SampleSuite", rep, func(s *Spec) {
+		builder := s.Paths(func(pb *PathBuilder) { pb.Bool("vip") })
+		builder.Sample(samples).Seed(7).It("sample case", func(ctx *Context) {})
+	})
+
+	if len(rep.specStarted) != samples {
+		t.Fatalf("expected %d SpecStarted events, got %d: %+v", samples, len(rep.specStarted), rep.specStarted)
+	}
+	if len(rep.specFinished) != samples {
+		t.Fatalf("expected %d SpecFinished events, got %d: %+v", samples, len(rep.specFinished), rep.specFinished)
+	}
+	if len(rep.suiteFinished) != 1 || rep.suiteFinished[0].TotalSpecs != samples {
+		t.Fatalf("expected TotalSpecs=%d, got %+v", samples, rep.suiteFinished)
+	}
+}
+
+// TestDescribeWithReporterStopsAtFirstFailingCandidate proves that when a generated candidate
+// fails, the reporter sees exactly that many SpecStarted/SpecFinished pairs — matching
+// proposalController's existing "stop at first failure" behavior instead of silently continuing
+// past it or reporting candidates that never ran.
+func TestDescribeWithReporterStopsAtFirstFailingCandidate(t *testing.T) {
+	rep := &recordingReporter{}
+	DescribeWithReporter(t, "FailingSampleSuite", rep, func(s *Spec) {
+		builder := s.Paths(func(pb *PathBuilder) { pb.Bool("vip") })
+		builder.Sample(5).Seed(7).It("always fails", func(ctx *Context) { ctx.recordFailure() })
+	})
+
+	if len(rep.specStarted) != len(rep.specFinished) {
+		t.Fatalf("expected matched SpecStarted/SpecFinished counts, got %d started, %d finished",
+			len(rep.specStarted), len(rep.specFinished))
+	}
+	if len(rep.specFinished) == 0 {
+		t.Fatal("expected at least one SpecFinished event")
+	}
+	last := rep.specFinished[len(rep.specFinished)-1]
+	if !last.Failed {
+		t.Fatalf("expected the last reported candidate to be the failing one, got %+v", last)
+	}
+	if len(rep.suiteFinished) != 1 || rep.suiteFinished[0].FailedSpecs != 1 {
+		t.Fatalf("expected exactly one FailedSpecs, got %+v", rep.suiteFinished)
+	}
+}
+
+// TestDescribeWithoutReporterEmitsNoEvents proves the default (no reporter) path stays exactly as
+// it was: passing a nil reporter causes no events, no panics, and no behavior change.
+func TestDescribeWithoutReporterEmitsNoEvents(t *testing.T) {
+	var ran bool
+	DescribeWithReporter(t, "NoReporterSuite", nil, func(s *Spec) {
+		s.It("runs", func(ctx *Context) { ran = true })
+	})
+	if !ran {
+		t.Fatal("expected the spec to still run with a nil reporter")
+	}
+}

--- a/specs/spec.go
+++ b/specs/spec.go
@@ -14,6 +14,7 @@ type Spec struct {
 	tb       testing.TB
 	backend  testBackend
 	reporter report.EventReporter
+	name     string // top-level Describe/DescribeFlat name, used as SuiteStartEvent/SuiteEndEvent.Name
 	seed     int64
 	hasSeed  bool
 
@@ -55,7 +56,7 @@ func Describe(tb testing.TB, name string, fn func(*Spec)) {
 	if tb != nil {
 		backend = asTestBackend(tb)
 	}
-	s := &Spec{tb: tb, backend: backend, arena: CurrentArena(), rootID: rootID, registry: currentRegistry()}
+	s := &Spec{tb: tb, backend: backend, name: name, arena: CurrentArena(), rootID: rootID, registry: currentRegistry()}
 	if fn != nil {
 		fn(s)
 	}
@@ -77,7 +78,7 @@ func describeWithCompilerContext(tb testing.TB, runCtx context.Context, name str
 	if tb != nil {
 		backend = asTestBackend(tb)
 	}
-	s := &Spec{tb: tb, backend: backend, reporter: rep, flat: flat, compiler: c}
+	s := &Spec{tb: tb, backend: backend, reporter: rep, name: name, flat: flat, compiler: c}
 	if fn != nil {
 		fn(s)
 	}
@@ -136,7 +137,7 @@ func DescribeWithReporter(tb testing.TB, name string, rep report.EventReporter, 
 	if tb != nil {
 		backend = asTestBackend(tb)
 	}
-	s := &Spec{tb: tb, backend: backend, reporter: rep, arena: CurrentArena(), rootID: rootID, registry: currentRegistry()}
+	s := &Spec{tb: tb, backend: backend, reporter: rep, name: name, arena: CurrentArena(), rootID: rootID, registry: currentRegistry()}
 	if fn != nil {
 		fn(s)
 	}
@@ -163,7 +164,7 @@ func DescribeFlat(tb testing.TB, name string, fn func(*Spec)) {
 	if tb != nil {
 		backend = asTestBackend(tb)
 	}
-	s := &Spec{tb: tb, backend: backend, arena: CurrentArena(), rootID: rootID, flat: true, registry: currentRegistry()}
+	s := &Spec{tb: tb, backend: backend, name: name, arena: CurrentArena(), rootID: rootID, flat: true, registry: currentRegistry()}
 	if fn != nil {
 		fn(s)
 	}
@@ -190,7 +191,7 @@ func DescribeFlatWithReporter(tb testing.TB, name string, rep report.EventReport
 	if tb != nil {
 		backend = asTestBackend(tb)
 	}
-	s := &Spec{tb: tb, backend: backend, reporter: rep, arena: CurrentArena(), rootID: rootID, flat: true, registry: currentRegistry()}
+	s := &Spec{tb: tb, backend: backend, reporter: rep, name: name, arena: CurrentArena(), rootID: rootID, flat: true, registry: currentRegistry()}
 	if fn != nil {
 		fn(s)
 	}
@@ -240,7 +241,7 @@ func (s *Spec) Compile() {
 	}
 	s.compileOnce.Do(func() {
 		if s.plan != nil {
-			s.suite = &CompiledSuite{Plan: s.plan, Arena: nil, RootID: 0}
+			s.suite = &CompiledSuite{Plan: s.plan, Arena: nil, RootID: 0, Name: s.name, Reporter: s.reporter}
 			return
 		}
 		if s.arena == nil {
@@ -250,7 +251,7 @@ func (s *Spec) Compile() {
 		defer planScratchPool.Put(scratch)
 		plan := newExecutionPlan(countSpecsArena(s.arena, s.rootID))
 		buildExecutionPlanFromArena(s.arena, s.rootID, plan, scratch)
-		s.suite = &CompiledSuite{Plan: plan, Arena: s.arena, RootID: s.rootID}
+		s.suite = &CompiledSuite{Plan: plan, Arena: s.arena, RootID: s.rootID, Name: s.name, Reporter: s.reporter}
 	})
 }
 


### PR DESCRIPTION
## Problem

Part of #12. `Spec.reporter report.EventReporter` is correctly threaded through the whole DSL tree (`Describe`/`When` propagate it to child Specs, `DescribeWithReporter`/`DescribeFlatWithReporter`/`DescribeFastWithReporter` all accept it), but `Spec.Compile()` never passed it into `CompiledSuite`, which had no `Reporter` field at all. `CompiledSuite.run` manufactured its own throwaway `report.New(io.Discard)` and threaded that through `runPlanFlatNoSubtests`/`runExecutionContext` instead — but no method on it, or on the real caller-supplied reporter, was ever called anywhere in the call chain. The reporter parameter was pure dead plumbing: `DescribeFastWithReporter`'s own doc comment already claimed "rep receives SuiteStarted/SuiteFinished and SpecStarted/SpecFinished events for the run", but that was aspirational, not true.

Note: part of #12's original evidence is stale — it claimed `DescribeFastWithReporter` took a concrete `*report.Reporter`; it's already correctly typed as the `report.EventReporter` interface. The real bug is more severe than described: not "output goes to `io.Discard`", but "no event is ever emitted at all".

#12 also mixed two architecturally distinct execution models: `ExecutionPlan`/`CompiledSuite` (used by `Describe`/`DescribeFlat`/`DescribeFast`, which already has the reporter field) and `Program`/`Runner`/`RunShard` (which has zero reporter concept). This PR is scoped to the former only, per explicit split agreed on the issue.

## Scope

- `ExecutionPlan`/`CompiledSuite` reporting only (this PR).
- `Program`/`Runner`/`RunShard` reporting is a separate follow-up PR, once this lands — that representation needs its own design for how a reporter gets injected.
- No unification between `CompiledSuite` and `Program` attempted here.
- No event-payload extension for candidate/combo names (e.g. `[tier=basic]`, `sample=1`) — `TestPathsReporterIncludesCombinationNames` and `TestPathsSampleReporterNamesIncludeSample` (both pre-existing, both `t.Skip("generated reporting is deferred until the later reporting gate")`) stay skipped.

## Fix

- `CompiledSuite` gains `Name string` (suite name for `SuiteStartEvent`/`SuiteEndEvent`, falls back to the backend's name if empty) and `Reporter report.EventReporter`.
- `Spec` gains a `name string` field (the top-level `Describe`/`DescribeFlat` name), set at all four top-level entry points (`Describe`, `DescribeWithReporter`, `DescribeFlat`, `DescribeFlatWithReporter`) and in `describeWithCompilerContext`. `Spec.Compile()` now passes both `s.name` and `s.reporter` into `CompiledSuite` in both branches (bytecode-compiler plan and arena-based plan).
- `CompiledSuite.run`: removed the dead `report.New(io.Discard)`. When `s.Reporter == nil`, behavior is byte-for-byte identical to before (no events, no overhead). When set, it wraps the reporter in a `specCounter` decorator that tallies every `SpecFinished` event (Paths() can execute a variable number of candidates per plan index, so the plan alone can't know the count up front), emits `SuiteStarted` before the run and `SuiteFinished` after with the real `TotalSpecs`/`FailedSpecs`.
- `runPlanFlatNoSubtests`/`runExecution`/`runExecutionContext`: `rep *report.Reporter` → `rep report.EventReporter` (matches the interface already used everywhere else; zero test-call-site changes needed since all existing callers already pass `nil`).
- `runExecutionContext` emits `SpecStarted`/`SpecFinished` in both branches:
  - PathGens-driven branch (Cartesian, Sample, Explore, ExploreCoverage, ExploreSmart): once per **executed candidate**, wrapping each `runIsolatedCase` call — not just the final accepted one. Hiding intermediate/rejected-then-retried candidates would misrepresent how many executions actually happened, how long the suite really took, and where a failure occurred; Explore in particular needs to execute candidates to get feedback, so those are real executions worth reporting.
  - Flat/non-generated branch: one `SpecStarted`/`SpecFinished` pair per spec, `Failed` from `ctx.failed` after `runProgram` returns.
- Event payload stays minimal: `Name` is `plan.Names[i]` (the It node's own name), `Path` is `plan.FullNames[i]`'s slash-joined breadcrumb split back into segments. Both helpers (`specEventName`/`specEventPath`) are bounds-safe against a hand-built `ExecutionPlan` that doesn't populate `Names`/`FullNames` (an existing test does exactly this).

## Tests

New `specs/execution_plan_reporter_test.go`, using a `recordingReporter` test double (structured event capture, not string-format assertions):
- A flat spec emits exactly one `SpecStarted`/`SpecFinished` pair, wrapped by one `SuiteStarted`/`SuiteFinished` pair with the right name and counts.
- A failing flat spec (body calls `ctx.recordFailure()` — what the framework's own `Expect(...)` matchers do internally on a real assertion failure) is reported `Failed` on its own event and counted in `SuiteEndEvent.FailedSpecs`.
- A Cartesian `Paths()` spec with 2 combos emits 2 `SpecStarted`/`SpecFinished` pairs (not 1), `TotalSpecs=2`.
- A `Sample(4)` spec emits 4 pairs, `TotalSpecs=4`.
- A failing generated candidate is reported `Failed=true`, and — matching `proposalController`'s existing "stop at first failure" semantics — `FailedSpecs=1` with the failing candidate as the last event.
- A `nil` reporter still runs the spec correctly (no panic, no behavior change).

Note on test design: the two failing-spec tests call `ctx.recordFailure()` directly instead of `ctx.T.Errorf`/`Fatalf`. `recordFailure()` only flips `Context`'s internal `failed` flag (the same thing `Expect(...)` calls internally on a real failed assertion) without calling anything on the real `*testing.T` — using `ctx.T.Errorf` would fail the real subtest, which bubbles up and fails this repo's own test suite. This exercises the exact same `Failed`-tracking path a real assertion failure takes, without that side effect.

## Validation

- `gofmt -l` — clean
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — clean
- `go test ./... -race -count=2` — clean
- `make build` — clean
- `make lint` — 0 issues
- Confirmed both pre-existing skipped reporter tests (`TestPathsReporterIncludesCombinationNames`, `TestPathsSampleReporterNamesIncludeSample`) still skip, unchanged.

## Relationship

Part of #12. Next: PR #12-B brings `Program`/`Runner`/`RunShard` reporting to parity, designing a minimal common boundary only once this implementation is live. #12 stays open until #12-B also lands.
