### PR TITLE
PR #12-B: wire report.EventReporter into Program/Runner/RunShard

### DIFF
--- a/specs/builder.go
+++ b/specs/builder.go
@@ -23,6 +23,7 @@ const (
 // specItem is one registered spec (or skip). Before/after enable coalescing; hookKey identifies the scope set.
 type specItem struct {
 	kind    specKind
+	name    string // the It/ItParallel name, for SpecStartEvent.Name; "" for skip (its steps are dropped anyway)
 	before  []step
 	spec    step // single spec body; nil for skip
 	after   []step
@@ -146,6 +147,7 @@ func (b *Builder) It(name string, fn interface{}) {
 	b.ensureScope()
 	b.pending = append(b.pending, specItem{
 		kind:    kindNormal,
+		name:    name,
 		before:  b.emitBefore(),
 		spec:    step(f),
 		after:   b.emitAfter(),
@@ -168,6 +170,7 @@ func (b *Builder) FIt(name string, fn func(*Context)) {
 	b.hasFocus = true
 	b.pending = append(b.pending, specItem{
 		kind:    kindFocus,
+		name:    name,
 		before:  b.emitBefore(),
 		spec:    step(fn),
 		after:   b.emitAfter(),
@@ -186,7 +189,7 @@ func (b *Builder) ItParallel(name string, fn func(*Context)) {
 		return
 	}
 	b.ensureScope()
-	b.pending = append(b.pending, specItem{kind: kindParallel, steps: b.emitSpecSteps(fn)})
+	b.pending = append(b.pending, specItem{kind: kindParallel, name: name, steps: b.emitSpecSteps(fn)})
 }
 
 // hookKey returns a key that uniquely identifies the current scope stack and hook set.
@@ -228,20 +231,27 @@ func (b *Builder) finalize() {
 		if it.kind == kindParallel {
 			curIdx = -1
 			parSteps := []step{runAll(it.steps)}
+			parNames := []string{it.name}
 			j := i + 1
 			for j < len(items) && items[j].kind == kindParallel {
 				parSteps = append(parSteps, runAll(items[j].steps))
+				parNames = append(parNames, items[j].name)
 				j++
 			}
-			groups = append(groups, group{specs: []step{parallelStep(parSteps)}})
+			// names is left nil: this group's single spec is the synthetic parallelStep closure,
+			// which reports each real ItParallel spec itself (via ctx.execObserver) as it runs on
+			// its own goroutine. Runner.Run's sequential per-spec reporting only fires when names
+			// is populated, so it correctly stays out of the way here instead of double-reporting.
+			groups = append(groups, group{specs: []step{parallelStep(parSteps, parNames)}})
 			i = j - 1
 			continue
 		}
 		// normal or focus: coalesce if same hook set (same scope layout) as current group
 		if curIdx >= 0 && groups[curIdx].hookKey == it.hookKey {
 			groups[curIdx].specs = append(groups[curIdx].specs, it.spec)
+			groups[curIdx].names = append(groups[curIdx].names, it.name)
 		} else {
-			groups = append(groups, group{before: it.before, specs: []step{it.spec}, after: it.after, hookKey: it.hookKey})
+			groups = append(groups, group{before: it.before, specs: []step{it.spec}, names: []string{it.name}, after: it.after, hookKey: it.hookKey})
 			curIdx = len(groups) - 1
 		}
 	}

--- a/specs/context.go
+++ b/specs/context.go
@@ -42,6 +42,11 @@ type Context struct {
 	failed bool
 	// failFast is set by Runner when FailFast is true; runner breaks after a step that set failed.
 	failFast bool
+	// execObserver, when non-nil, receives per-spec Started/Finished notifications from execution
+	// points that only have a Context to work with (e.g. a parallelStep goroutine, which has no
+	// Runner reference). Installed by Runner.Run only when it has a report.EventReporter; nil
+	// otherwise, so execution is unaffected without one.
+	execObserver specExecutionObserver
 }
 
 // NewContext builds a context for the given test/bench. Use *testing.T or *testing.B.
@@ -65,6 +70,7 @@ func (c *Context) Reset(backend testBackend) {
 	c.T = nil
 	c.coverage = nil
 	c.failed = false
+	c.execObserver = nil
 	if backend != nil {
 		// runnableBackend wraps the subtest T; unwrap so ctx.T points to the current subtest.
 		if r, ok := backend.(*runnableBackend); ok {

--- a/specs/program.go
+++ b/specs/program.go
@@ -5,6 +5,8 @@ package specs
 import (
 	"fmt"
 	"sync"
+
+	"github.com/pablogore/go-specs/report"
 )
 
 // step is a single executable step (hook or spec body). Same signature as RunSpec.Fn.
@@ -13,11 +15,35 @@ type step func(*Context)
 // group is one execution unit: run before once, then all specs, then after once (reverse order).
 // Before/after slices are shared across all specs in the group to reduce memory and improve locality.
 // hookKey is the builder's scope key for coalescing; not used by the runner.
+//
+// names holds one entry per group.specs entry (SpecStartEvent.Name), or is left nil for a group
+// whose single spec is a parallelStep closure: that closure reports each real spec itself (see
+// parallelStep), so Runner.Run's sequential per-spec reporting must not also wrap it.
 type group struct {
 	before  []step
 	specs   []step
+	names   []string
 	after   []step
 	hookKey string
+}
+
+// specName returns names[i], or "" when names doesn't cover index i (an unnamed spec, e.g. from
+// AddSpec, or a group that reports its own specs internally — see group.names).
+func specName(names []string, i int) string {
+	if i < 0 || i >= len(names) {
+		return ""
+	}
+	return names[i]
+}
+
+// specExecutionObserver receives per-spec Started/Finished notifications from execution points
+// that only have a *Context to work with, not a *Runner reference — namely a parallelStep
+// goroutine, compiled into the Program before any Runner or Reporter exists. Runner.Run installs
+// one on Context only when it has a report.EventReporter; nil otherwise, so a parallel group's
+// execution is unaffected without one.
+type specExecutionObserver interface {
+	specStarted(name string) report.SpecStartEvent
+	specFinished(start report.SpecStartEvent, failed bool)
 }
 
 // Program is a compiled execution program. Groups run in order; within a group: before once, all specs, after once (reverse).
@@ -63,16 +89,28 @@ func runAll(steps []step) step {
 // parallelBackend cannot safely expose a live *testing.T (doing so would let a spec body call
 // t.Fatalf from the wrong goroutine, reintroducing the race this fixes), so child.T is nil inside
 // an ItParallel body; use ctx.Expect(...) instead of ctx.T directly.
-func parallelStep(steps []step) step {
+//
+// names holds one entry per steps entry (its ItParallel name); when the caller's Context has an
+// execObserver (i.e. Runner.Run has a Reporter), each goroutine reports its own spec directly —
+// SpecStarted right before running it, SpecFinished once results[i] is known (after classifying
+// nil/parallelAbort{}/a real panic) — instead of the group being reported as a single opaque unit.
+// Failed is that spec's own result, not the group's aggregate ctx.failed. Events from different
+// goroutines may interleave in any order; only started-before-finished is guaranteed per spec.
+// obs is read once from ctx before any goroutine starts, then only read (never mutated) by them,
+// so no synchronization is needed for the pointer itself; obs's own methods serialize the actual
+// report.EventReporter calls, since not every EventReporter implementation is concurrency-safe.
+func parallelStep(steps []step, names []string) step {
 	return func(ctx *Context) {
 		if len(steps) == 0 {
 			return
 		}
 		pathValues := ctx.Path()
+		obs := ctx.execObserver
 		results := make([]string, len(steps))
 		var wg sync.WaitGroup
 		for i, s := range steps {
 			i, s := i, s
+			name := specName(names, i)
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -80,6 +118,10 @@ func parallelStep(steps []step) step {
 				child := contextPool.Get().(*Context)
 				child.Reset(backend)
 				child.SetPathValues(pathValues)
+				var started report.SpecStartEvent
+				if obs != nil {
+					started = obs.specStarted(name)
+				}
 				defer func() {
 					switch r := recover(); r {
 					case nil:
@@ -92,6 +134,9 @@ func parallelStep(steps []step) step {
 						if results[i] == "" {
 							results[i] = fmt.Sprintf("panic: %v", r)
 						}
+					}
+					if obs != nil {
+						obs.specFinished(started, results[i] != "")
 					}
 					child.Reset(nil)
 					contextPool.Put(child)

--- a/specs/program_test.go
+++ b/specs/program_test.go
@@ -201,7 +201,7 @@ func TestParallelStep_PanicRecovered(t *testing.T) {
 	ctx := &Context{backend: backend}
 	run := parallelStep([]step{
 		runAll([]step{func(*Context) { panic("boom") }}),
-	})
+	}, nil)
 	run(ctx) // must return normally; an unrecovered panic here would crash the whole test binary
 	if !backend.failed {
 		t.Error("expected the panic to be reported as a spec failure")
@@ -226,7 +226,7 @@ func TestParallelStep_FatalAssertionStopsSpecBody(t *testing.T) {
 			ctx.Expect(1).ToEqual(2)
 			ranAfterFailure = true // must not run: the assertion above is fatal
 		}}),
-	})
+	}, nil)
 	run(ctx)
 	if !backend.failed {
 		t.Fatal("expected a failure to be reported")
@@ -253,7 +253,7 @@ func TestParallelStep_FatalAssertionSkipsRemainingSteps(t *testing.T) {
 			func(ctx *Context) { ctx.Expect(1).ToEqual(2) }, // the spec body, fails fatally
 			func(*Context) { afterRan = true },              // stands in for a baked-in AfterEach
 		}),
-	})
+	}, nil)
 	run(ctx)
 	if !backend.failed {
 		t.Fatal("expected a failure to be reported")
@@ -277,7 +277,7 @@ func TestParallelStep_NonFatalErrorDoesNotAbort(t *testing.T) {
 			ctx.backend.Error("logged, non-fatal")
 			ranAfterError = true
 		}}),
-	})
+	}, nil)
 	run(ctx)
 	if !ranAfterError {
 		t.Error("expected code after a non-fatal Error to still run")
@@ -309,7 +309,7 @@ func TestParallelStep_FailFastRunsAllSpecsInGroup(t *testing.T) {
 			ctx.Expect(1).ToEqual(2)
 		}}),
 		runAll([]step{func(*Context) { mark("sibling") }}),
-	})
+	}, nil)
 	run(ctx)
 
 	if !ran["fails"] || !ran["sibling"] {
@@ -327,7 +327,7 @@ func TestParallelStep_NilCtxT(t *testing.T) {
 	var sawNilT bool
 	run := parallelStep([]step{
 		runAll([]step{func(ctx *Context) { sawNilT = ctx.T == nil }}),
-	})
+	}, nil)
 	run(NewContext(t))
 	if !sawNilT {
 		t.Error("expected ctx.T to be nil inside an ItParallel body")

--- a/specs/runner.go
+++ b/specs/runner.go
@@ -1,15 +1,28 @@
-// runner.go executes a compiled Program. No hook resolution at runtime; no allocations in the loop.
+// runner.go executes a compiled Program. No hook resolution at runtime; no allocations in the loop
+// unless a Reporter is set.
 package specs
 
 import (
 	"runtime/debug"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/pablogore/go-specs/report"
 )
 
 // Runner runs a compiled Program against a test backend. One context from the pool, reused for every step.
 type Runner struct {
 	program  *Program
 	FailFast bool // if true, stop after the first step that sets ctx.failed (e.g. assertion failure)
+
+	// Name and Reporter are optional: when Reporter is nil, Run behaves exactly as it did before
+	// either field existed — no events, no extra work. When set, Run emits SuiteStarted before the
+	// program runs and SuiteFinished after, with SpecStarted/SpecFinished around every named spec
+	// (see group.names) — including each real spec inside an ItParallel group, reported from its own
+	// goroutine (see parallelStep). Name falls back to the backend's name if empty.
+	Name     string
+	Reporter report.EventReporter
 }
 
 // NewRunner creates a runner for the given program. Program must not be nil; do not modify program.Groups after creation.
@@ -22,8 +35,48 @@ func NewRunnerFromProgram(program *Program) *Runner {
 	return NewRunner(program)
 }
 
+// NewRunnerWithReporter creates a runner that reports SuiteStarted/SuiteFinished and
+// SpecStarted/SpecFinished events to rep as the program runs. name is used for
+// SuiteStartEvent/SuiteEndEvent.Name; if empty, the backend's name is used instead.
+func NewRunnerWithReporter(program *Program, name string, rep report.EventReporter) *Runner {
+	return &Runner{program: program, Name: name, Reporter: rep}
+}
+
+// reporterObserver adapts a report.EventReporter to specExecutionObserver, serializing calls with a
+// mutex: a parallel group's goroutines call specStarted/specFinished concurrently, and not every
+// EventReporter implementation can be assumed to be concurrency-safe on its own — the framework
+// serializes on its behalf instead of expanding EventReporter's contract to require it. total/failed
+// tally every reported spec (sequential and parallel alike, since both paths share one instance via
+// ctx.execObserver) for the run's SuiteEndEvent.
+type reporterObserver struct {
+	mu     sync.Mutex
+	rep    report.EventReporter
+	total  int
+	failed int
+}
+
+func (o *reporterObserver) specStarted(name string) report.SpecStartEvent {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	e := report.SpecStartEvent{Name: name, Time: time.Now()}
+	o.rep.SpecStarted(e)
+	return e
+}
+
+func (o *reporterObserver) specFinished(start report.SpecStartEvent, failed bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.total++
+	if failed {
+		o.failed++
+	}
+	o.rep.SpecFinished(report.SpecResultEvent{SpecStartEvent: start, Failed: failed})
+}
+
+var _ specExecutionObserver = (*reporterObserver)(nil)
+
 // Run executes all groups in order. Within each group: before once, all specs, then after once (reverse order).
-// Zero allocations in the loop; deterministic.
+// Zero allocations in the loop when Reporter is nil; deterministic.
 //
 // A panic in before, a spec, or an after hook is recovered instead of crashing the process — see
 // runGroup for the exact contract (which specs still run, whether after still runs).
@@ -44,7 +97,25 @@ func (r *Runner) Run(tb testing.TB) {
 		ctx.SetFailFast(true)
 	}
 
+	if r.Reporter == nil {
+		runGroups(ctx, r.program.Groups)
+		return
+	}
+
+	name := r.Name
+	if name == "" {
+		name = backend.Name()
+	}
+	obs := &reporterObserver{rep: r.Reporter}
+	ctx.execObserver = obs
+	r.Reporter.SuiteStarted(report.SuiteStartEvent{Name: name, Time: time.Now()})
 	runGroups(ctx, r.program.Groups)
+	r.Reporter.SuiteFinished(report.SuiteEndEvent{
+		Name:        name,
+		Time:        time.Now(),
+		TotalSpecs:  obs.total,
+		FailedSpecs: obs.failed,
+	})
 }
 
 // runGroups runs each group in order, stopping before the next group if FailFast is set and a
@@ -86,7 +157,7 @@ func runGroup(ctx *Context, g *group) {
 	if ctx.failFast && ctx.failed {
 		return
 	}
-	runSpecsRecovered(ctx, g.specs)
+	runSpecsRecovered(ctx, g)
 }
 
 // runBeforeRecovered runs a group's before hooks in order. Returns false if a panic stopped setup
@@ -110,10 +181,33 @@ func runBeforeRecovered(ctx *Context, before []step) (ok bool) {
 }
 
 // runSpecsRecovered runs a group's specs in order, recovering each one individually.
-func runSpecsRecovered(ctx *Context, specs []step) {
-	for _, s := range specs {
+//
+// ctx.failed is reset before every spec unconditionally — not gated on whether ctx.execObserver is
+// set — because gating it would make attaching a reporter change execution semantics; reporting must
+// stay purely observational. This also fixes a latent bug: without the reset, ctx.failed stuck true
+// after the first failing spec in a group and stayed true for the rest of this loop (harmless today,
+// since nothing outside the immediate failFast-gated checks ever read it, but a real correctness
+// issue for any future consumer, and now for reporting).
+//
+// When ctx.execObserver is set and this group has a name for index i (see group.names — left nil for
+// a parallel group, whose parallelStep closure reports its own real specs instead of one entry per
+// group.specs), SpecStarted/SpecFinished are emitted around the spec using its own captured failed
+// value, not any carry-over from a before hook or a previous spec.
+func runSpecsRecovered(ctx *Context, g *group) {
+	obs := ctx.execObserver
+	for i, s := range g.specs {
+		ctx.failed = false
+		named := obs != nil && i < len(g.names)
+		var started report.SpecStartEvent
+		if named {
+			started = obs.specStarted(g.names[i])
+		}
 		runStepRecovered(ctx, s, "panic")
-		if ctx.failFast && ctx.failed {
+		failed := ctx.failed
+		if named {
+			obs.specFinished(started, failed)
+		}
+		if ctx.failFast && failed {
 			return
 		}
 	}

--- a/specs/runner_reporter_test.go
+++ b/specs/runner_reporter_test.go
@@ -1,0 +1,216 @@
+package specs
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/pablogore/go-specs/report"
+)
+
+// TestRunnerWithReporterEmitsSuiteAndSpecEvents proves NewRunnerWithReporter's Runner reports the
+// same SuiteStarted/SpecStarted/SpecFinished/SuiteFinished shape as CompiledSuite/Describe do (see
+// execution_plan_reporter_test.go), for the separate Program/Runner execution model.
+func TestRunnerWithReporterEmitsSuiteAndSpecEvents(t *testing.T) {
+	rep := &recordingReporter{}
+	prog := BuildProgram(func(b *Builder) {
+		b.Describe("Suite", func() {
+			b.It("passes", func(ctx *Context) {})
+			b.It("fails", func(ctx *Context) { ctx.recordFailure() })
+		})
+	})
+
+	NewRunnerWithReporter(prog, "Suite", rep).Run(t)
+
+	if len(rep.suiteStarted) != 1 || rep.suiteStarted[0].Name != "Suite" {
+		t.Fatalf("expected one SuiteStarted for Suite, got %+v", rep.suiteStarted)
+	}
+	if len(rep.specStarted) != 2 {
+		t.Fatalf("expected two SpecStarted, got %+v", rep.specStarted)
+	}
+	if len(rep.specFinished) != 2 {
+		t.Fatalf("expected two SpecFinished, got %+v", rep.specFinished)
+	}
+	byName := map[string]bool{}
+	for _, e := range rep.specFinished {
+		byName[e.Name] = e.Failed
+	}
+	if failed, ok := byName["passes"]; !ok || failed {
+		t.Errorf("expected 'passes' to be reported as not failed, got %+v", rep.specFinished)
+	}
+	if failed, ok := byName["fails"]; !ok || !failed {
+		t.Errorf("expected 'fails' to be reported as failed, got %+v", rep.specFinished)
+	}
+	if len(rep.suiteFinished) != 1 {
+		t.Fatalf("expected one SuiteFinished, got %+v", rep.suiteFinished)
+	}
+	end := rep.suiteFinished[0]
+	if end.Name != "Suite" || end.TotalSpecs != 2 || end.FailedSpecs != 1 {
+		t.Fatalf("expected Suite TotalSpecs=2 FailedSpecs=1, got %+v", end)
+	}
+}
+
+// TestRunnerNilReporterMatchesReporterFailFastSemantics proves the ctx.failed-per-spec-reset fix
+// (required unconditionally, not gated on Reporter != nil — see runSpecsRecovered) does not change
+// FailFast behavior: with FailFast set, a failing spec still stops every later spec, whether or not
+// a Reporter is attached.
+func TestRunnerNilReporterMatchesReporterFailFastSemantics(t *testing.T) {
+	t.Run("without reporter", func(t *testing.T) {
+		var ranSecond bool
+		prog := BuildProgram(func(b *Builder) {
+			b.Describe("Suite", func() {
+				b.It("first", func(ctx *Context) { ctx.recordFailure() })
+				b.It("second", func(ctx *Context) { ranSecond = true })
+			})
+		})
+		r := NewRunner(prog)
+		r.FailFast = true
+		r.Run(t)
+		if ranSecond {
+			t.Error("expected FailFast to stop before the second spec")
+		}
+	})
+
+	t.Run("with reporter", func(t *testing.T) {
+		var ranSecond bool
+		prog := BuildProgram(func(b *Builder) {
+			b.Describe("Suite", func() {
+				b.It("first", func(ctx *Context) { ctx.recordFailure() })
+				b.It("second", func(ctx *Context) { ranSecond = true })
+			})
+		})
+		rep := &recordingReporter{}
+		r := NewRunnerWithReporter(prog, "Suite", rep)
+		r.FailFast = true
+		r.Run(t)
+		if ranSecond {
+			t.Error("expected FailFast to stop before the second spec")
+		}
+		if len(rep.specFinished) != 1 || rep.specFinished[0].Name != "first" || !rep.specFinished[0].Failed {
+			t.Fatalf("expected only 'first' to be reported, as failed, got %+v", rep.specFinished)
+		}
+	})
+}
+
+// TestParallelStepWithObserverReportsEachSpecIndividually proves each real ItParallel spec is
+// reported individually (one SpecStarted/SpecFinished pair per spec, not one for the whole opaque
+// group), with Failed derived from that spec's own result (results[i], the same per-index tracking
+// reportFailures already uses), not the group's aggregate ctx.failed. Exercises parallelStep
+// directly against a capturingBackend, like program_test.go's other parallelStep tests, so a
+// (deliberately) failing spec here never reaches a real *testing.T's Fatalf/Goexit.
+func TestParallelStepWithObserverReportsEachSpecIndividually(t *testing.T) {
+	rep := &recordingReporter{}
+	obs := &reporterObserver{rep: rep}
+	backend := &capturingBackend{}
+	ctx := &Context{backend: backend, execObserver: obs}
+
+	run := parallelStep([]step{
+		runAll([]step{func(*Context) {}}),
+		runAll([]step{func(ctx *Context) { ctx.backend.Error("boom") }}),
+		runAll([]step{func(*Context) {}}),
+	}, []string{"p1", "p2", "p3"})
+	run(ctx)
+
+	if !backend.failed {
+		t.Fatal("expected the group's failure (from p2) to still be reported on the outer backend")
+	}
+	if len(rep.specStarted) != 3 {
+		t.Fatalf("expected three SpecStarted (one per real ItParallel spec), got %+v", rep.specStarted)
+	}
+	if len(rep.specFinished) != 3 {
+		t.Fatalf("expected three SpecFinished, got %+v", rep.specFinished)
+	}
+	var names []string
+	byName := map[string]bool{}
+	for _, e := range rep.specFinished {
+		names = append(names, e.Name)
+		byName[e.Name] = e.Failed
+	}
+	sort.Strings(names)
+	if got := names; len(got) != 3 || got[0] != "p1" || got[1] != "p2" || got[2] != "p3" {
+		t.Fatalf("expected p1/p2/p3 each reported once, got %v", names)
+	}
+	if byName["p1"] || byName["p3"] {
+		t.Errorf("expected p1/p3 to be reported as not failed, got %+v", rep.specFinished)
+	}
+	if !byName["p2"] {
+		t.Errorf("expected p2 to be reported as failed, got %+v", rep.specFinished)
+	}
+	if obs.total != 3 || obs.failed != 1 {
+		t.Fatalf("expected observer to tally total=3 failed=1, got total=%d failed=%d", obs.total, obs.failed)
+	}
+}
+
+// TestRunnerWithReporterItParallelSharesRunnerObserver proves a passing ItParallel group, run
+// through the real Runner (not parallelStep directly), reports through the same observer instance
+// as the surrounding sequential specs — so SuiteEndEvent.TotalSpecs counts both kinds together.
+func TestRunnerWithReporterItParallelSharesRunnerObserver(t *testing.T) {
+	rep := &recordingReporter{}
+	prog := BuildProgram(func(b *Builder) {
+		b.Describe("Suite", func() {
+			b.It("sequential", func(ctx *Context) {})
+			b.ItParallel("p1", func(ctx *Context) {})
+			b.ItParallel("p2", func(ctx *Context) {})
+		})
+	})
+
+	NewRunnerWithReporter(prog, "Suite", rep).Run(t)
+
+	if len(rep.specStarted) != 3 {
+		t.Fatalf("expected three SpecStarted (1 sequential + 2 parallel), got %+v", rep.specStarted)
+	}
+	if len(rep.suiteFinished) != 1 {
+		t.Fatalf("expected one SuiteFinished, got %+v", rep.suiteFinished)
+	}
+	end := rep.suiteFinished[0]
+	if end.TotalSpecs != 3 || end.FailedSpecs != 0 {
+		t.Fatalf("expected TotalSpecs=3 FailedSpecs=0, got %+v", end)
+	}
+}
+
+// TestRunShardWithReporterCountsOnlyShardSpecs proves SuiteEndEvent.TotalSpecs for a shard reflects
+// only the specs that shard actually executed, not the full Program's total — the reporter describes
+// the concrete execution that happened, not the unsharded program.
+func TestRunShardWithReporterCountsOnlyShardSpecs(t *testing.T) {
+	// Built as four distinct groups directly (not via the Builder), so this test isn't at the mercy
+	// of finalize()'s hook-based coalescing merging same-hookKey Describes (all hookless here) into
+	// one group — RunShard shards by group index, so it needs four real groups to split across.
+	noop := func(*Context) {}
+	prog := &Program{Groups: []group{
+		{specs: []step{noop}, names: []string{"a"}},
+		{specs: []step{noop}, names: []string{"b"}},
+		{specs: []step{noop}, names: []string{"c"}},
+		{specs: []step{noop}, names: []string{"d"}},
+	}}
+
+	rep := &recordingReporter{}
+	RunShardWithReporter(prog, t, 0, 2, "Shard0", rep)
+
+	if len(rep.suiteFinished) != 1 {
+		t.Fatalf("expected one SuiteFinished, got %+v", rep.suiteFinished)
+	}
+	end := rep.suiteFinished[0]
+	if end.TotalSpecs != 2 {
+		t.Fatalf("expected shard 0 of 2 to report TotalSpecs=2 (half of 4), got %+v", end)
+	}
+	if len(rep.specStarted) != 2 {
+		t.Fatalf("expected two SpecStarted for this shard, got %+v", rep.specStarted)
+	}
+}
+
+// TestRunnerNilReporterNoObserver proves a Runner without a Reporter never installs an
+// execObserver, so it takes zero extra branches beyond the ordinary nil check — same invariant as
+// #12-A: no reporter, no observable difference in execution.
+func TestRunnerNilReporterNoObserver(t *testing.T) {
+	var sawObserver bool
+	prog := BuildProgram(func(b *Builder) {
+		b.Describe("Suite", func() {
+			b.It("spec", func(ctx *Context) { sawObserver = ctx.execObserver != nil })
+		})
+	})
+	NewRunner(prog).Run(t)
+	if sawObserver {
+		t.Error("expected ctx.execObserver to be nil without a Reporter")
+	}
+}
+
+var _ report.EventReporter = (*recordingReporter)(nil)

--- a/specs/scheduler.go
+++ b/specs/scheduler.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+
+	"github.com/pablogore/go-specs/report"
 )
 
 // parallelAbort is the sentinel panic value FailNow/Fatal/Fatalf use, when abortOnFatal is set, to
@@ -162,9 +164,33 @@ func RunShard(program *Program, tb testing.TB, shardIndex, shardCount int) {
 	if program == nil || tb == nil {
 		return
 	}
-	if shardCount <= 0 || shardIndex < 0 || shardIndex >= shardCount {
-		NewRunner(program).Run(tb)
+	prog, ok := shardProgram(program, shardIndex, shardCount)
+	if !ok {
 		return
+	}
+	NewRunner(prog).Run(tb)
+}
+
+// RunShardWithReporter is RunShard with reporting: the runner it builds for the shard's Program
+// reports SuiteStarted/SuiteFinished and SpecStarted/SpecFinished exactly as NewRunnerWithReporter's
+// Runner would, so SuiteEndEvent.TotalSpecs/FailedSpecs describe only the specs this shard actually
+// executed, not the full Program's total — the sharding itself is unchanged from RunShard.
+func RunShardWithReporter(program *Program, tb testing.TB, shardIndex, shardCount int, name string, rep report.EventReporter) {
+	if program == nil || tb == nil {
+		return
+	}
+	prog, ok := shardProgram(program, shardIndex, shardCount)
+	if !ok {
+		return
+	}
+	NewRunnerWithReporter(prog, name, rep).Run(tb)
+}
+
+// shardProgram returns the Program for one shard: its groups (sharded groups when shardCount is
+// valid, all groups otherwise), or ok=false if this shard has nothing to run.
+func shardProgram(program *Program, shardIndex, shardCount int) (prog *Program, ok bool) {
+	if shardCount <= 0 || shardIndex < 0 || shardIndex >= shardCount {
+		return program, true
 	}
 	groups := program.Groups
 	sharded := make([]group, 0, len(groups)/shardCount+1)
@@ -174,8 +200,7 @@ func RunShard(program *Program, tb testing.TB, shardIndex, shardCount int) {
 		}
 	}
 	if len(sharded) == 0 {
-		return
+		return nil, false
 	}
-	prog := &Program{Groups: sharded}
-	NewRunner(prog).Run(tb)
+	return &Program{Groups: sharded}, true
 }


### PR DESCRIPTION
## Problem

Part of #12. #12-A (#70, merged) wired `report.EventReporter` into `ExecutionPlan`/`CompiledSuite` (the `Describe`/`DescribeFlat`/`DescribeFast` execution model). The other execution model in this codebase, `Program`/`Builder`/`Runner`/`RunShard` (reachable via `BuildProgram(fn)` or a manual `NewBuilder()`, executed via `NewRunner(prog).Run(tb)` or `RunShard(...)`), had zero reporter concept: no `Reporter` field on `Runner`, no spec/suite name kept anywhere in the compiled `Program` at all (`Builder.It(name, fn)` discarded `name` at compile time, and `BuildProgram(fn)` didn't even take a suite name parameter).

This PR brings the same functional event parity (`SuiteStarted`/`SpecStarted`/`SpecFinished`/`SuiteFinished`, real counts, correct failures) to that second execution model, without unifying it with `CompiledSuite` or redesigning `Program`/its bytecode format.

While investigating, also found (and fixed, since it's required for reporting to be trustworthy) a latent, previously-harmless bug: `Runner.Run` reset `ctx.failed` once before the whole run, never per-spec inside the specs loop, so once any spec failed, `ctx.failed` stayed `true` for the rest of that group's specs. This was invisible before because nothing outside the immediate `FailFast`-gated checks ever read it — but it would have silently mislabeled every spec after the first failure as "failed" once per-spec reporting existed.

## Scope

- `Program`/`Builder`/`Runner`/`RunShard` reporting only (this PR). `ExecutionPlan`/`CompiledSuite` reporting was #12-A (#70), already merged.
- `BytecodeRunner`/`BCBuilder`/`BCProgram` (`bytecode_impl.go`/`runner_bytecode.go`) stay out of scope: that's a third, disconnected, nameless execution primitive (`BCBuilder.AddSpec(fn func(*Context))` has no name parameter at all, not reachable from any `Describe*`/`BuildProgram` entry point). Giving it identity would be its own redesign, not additive reporting — a separate future issue if that API is ever meant to be covered.
- `specs/sharding.go`'s `ShardSpecs`/`ShardBCProgram` (a separate sharding mechanism feeding `MinimalRunner`/`BytecodeRunner`, distinct from `scheduler.go`'s `RunShard`) is untouched.
- No rich Path/combo names, no JUnit/JSON, no event-payload redesign — same functional-parity-only bar #12-A held.

## Fix

- `Runner` gains `Name string` and `Reporter report.EventReporter` (mirrors `CompiledSuite.Name`/`.Reporter`), plus `NewRunnerWithReporter(program, name, rep) *Runner`; `NewRunner` is untouched — a `Runner` built via `NewRunner` behaves exactly as before, byte-for-byte, no reporter, no extra branches beyond one nil check.
- `Builder.specItem` gains `name string`, threaded through `It`/`FIt`/`ItParallel`. `finalize()` builds a new `group.names []string`, aligned by index with `group.specs` for normal/focus groups (1:1 with real `It`/`FIt` calls). For a group compiled from `ItParallel` (whose single `specs` entry is a synthetic `parallelStep` closure, not a 1:1 real spec), `names` is deliberately left `nil` — see below.
- `runSpecsRecovered` (in `runner.go`) resets `ctx.failed = false` **unconditionally** before every `specs[i](ctx)` call — not gated on whether a `Reporter`/observer is present, because gating it would make attaching a reporter change execution semantics; reporting has to stay purely observational. It then captures `failed := ctx.failed` right after the step runs and uses that captured value both for the `SpecFinished` event and for the `FailFast` break check (previously `ctx.failed` was read directly at that point; behavior-preserving, since every existing consumer of `ctx.failed` was already inside an immediate `FailFast`-gated check, and `FailFast=true` plus a failure was already forcing an early return before any staleness could matter).
- `Runner.Run` installs a `*reporterObserver` (new type in `runner.go`, satisfies a new `specExecutionObserver` interface in `program.go`) on `ctx.execObserver` only when `r.Reporter != nil`, emits `SuiteStarted` before the group loop and `SuiteFinished` after with the observer's real `total`/`failed` tallies. `reporterObserver` mutex-serializes calls into the underlying `EventReporter` — see `ItParallel` below for why that's load-bearing, not decorative.
- **`ItParallel` groups** (the one place where `group.specs` doesn't map 1:1 to real specs — N real `It`-equivalents compile into one opaque `parallelStep` closure) get real per-spec reporting, not one synthetic event per batch: `parallelStep` now takes `names []string` and, when `ctx.execObserver` is set (read once before spawning goroutines, then only read, never mutated, by them — safe for concurrent reads as a pointer copy), each goroutine calls `obs.specStarted(name)` right before running its spec and `obs.specFinished(started, results[i] != "")` from its existing panic-recovery `defer`, once that spec's own result is known. `Failed` is derived from that spec's own `results[i]` (the same per-index tracking `reportFailures` already uses), not the group's aggregate `ctx.failed`. No ordering is promised between different specs' events, only started-before-finished per spec. `reporterObserver`'s mutex is what makes this safe: `EventReporter` implementations aren't newly required to be concurrency-safe themselves, the framework absorbs that.
- `RunShardWithReporter(program, tb, shardIndex, shardCount, name, rep)` mirrors `RunShard`, sharing its sharding logic (`shardProgram`, factored out of `RunShard`) and delegating to `NewRunnerWithReporter` instead of `NewRunner` — no duplicated lifecycle/event logic. `SuiteEndEvent.TotalSpecs`/`FailedSpecs` naturally reflect only that shard's real executed specs (not the full `Program`'s total), since the observer only counts what actually ran.
- `Context` gains an unexported `execObserver specExecutionObserver` field, cleared in `Reset` alongside `failed`/`coverage`/`T` — needed since `Context` is pooled (`contextPool`, shared by `CompiledSuite`, `Runner.Run`, and `parallelStep`'s per-goroutine children), so a stale observer from one `Runner.Run` call can't leak into a pooled `Context` reused by an unrelated execution.
- `specName(names []string, i int) string` (bounds-safe, mirrors #12-A's `specEventName`/`specEventPath`) returns `""` for an unnamed spec (`AddSpec("")`) or an out-of-range index.

## Tests

New `specs/runner_reporter_test.go`, reusing `recordingReporter` from `execution_plan_reporter_test.go` (already in-package):
- Sequential `Program` reporting: one `SpecStarted`/`SpecFinished` pair per spec with correct `Failed`, wrapped by one `SuiteStarted`/`SuiteFinished` with real `TotalSpecs`/`FailedSpecs`.
- `FailFast` parity: a failing first spec stops a second spec from running, identically with and without a `Reporter` attached — proves the `ctx.failed`-per-spec-reset fix didn't change existing `FailFast` semantics.
- `ItParallel` per-spec reporting, exercised directly against `parallelStep` with a `capturingBackend` (same pattern `program_test.go`'s other `parallelStep` tests already use, so a deliberately-failing spec here never reaches a real `*testing.T`'s `Fatalf`/`Goexit`): 3 parallel specs report 3 individual `SpecStarted`/`SpecFinished` pairs, the failing one's own `Failed=true` derived from its own result, the other two `Failed=false`.
- `ItParallel` sharing the same observer as sequential specs when run through the real `Runner` (not `parallelStep` directly): `SuiteEndEvent.TotalSpecs` counts both kinds together.
- `RunShardWithReporter`: built from four explicit `group`s (not via `Builder`, to sidestep `finalize()`'s hook-based coalescing of hookless Describes into one group, which is unrelated, pre-existing, correct behavior but would collapse this test's shards into one) — proves shard 0 of 2 reports `TotalSpecs=2`, only the specs that shard actually ran.
- Nil-`Reporter` path: `ctx.execObserver` stays `nil`, same invariant as #12-A — no reporter, no observable difference in execution.

## Validation

- `gofmt -l` on touched files — clean (repo has pre-existing gofmt drift in unrelated files not touched here)
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — clean
- `go test ./... -race -count=2` — clean (particularly relevant given the new concurrent `reporterObserver`/`ItParallel` path)
- `make build` — clean
- `make lint` — 0 issues

## Relationship

Part of #12. Both halves of #12 (`ExecutionPlan`/`CompiledSuite` in #12-A/#70, `Program`/`Runner`/`RunShard` here) are now done; `BytecodeRunner` reporting/identity remains deliberately out of scope for #12 as a whole and would need its own issue if ever wanted.
