### PR TITLE
fix(report): #13-A — real Duration on SpecResultEvent/SuiteEndEvent

### DIFF
--- a/report/events.go
+++ b/report/events.go
@@ -12,6 +12,7 @@ type SuiteStartEvent struct {
 type SuiteEndEvent struct {
 	Name        string
 	Time        time.Time
+	Duration    time.Duration // elapsed time between this suite's SuiteStartEvent and this event
 	TotalSpecs  int
 	FailedSpecs int
 }
@@ -24,10 +25,15 @@ type SpecStartEvent struct {
 }
 
 // SpecResultEvent captures the result of an individual spec.
+//
+// SpecStartEvent is always the exact event this spec's SpecStarted call sent (same Time, not
+// reconstructed at finish time) — Duration is measured against it, so a producer that rebuilds
+// SpecStartEvent here instead of reusing the original would silently corrupt Duration too.
 type SpecResultEvent struct {
 	SpecStartEvent
-	Failed  bool
-	Message string
+	Failed   bool
+	Duration time.Duration // elapsed time between SpecStartEvent.Time and this event
+	Message  string
 }
 
 // EventReporter consumes structured events from the spec runner.

--- a/report/reporter.go
+++ b/report/reporter.go
@@ -36,7 +36,7 @@ func (r *Reporter) SuiteFinished(e SuiteEndEvent) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.w != nil {
-		_, _ = fmt.Fprintf(r.w, "SuiteFinished %s\n", e.Name)
+		_, _ = fmt.Fprintf(r.w, "SuiteFinished %s duration=%s\n", e.Name, e.Duration)
 	}
 	r.path = nil
 }
@@ -55,7 +55,7 @@ func (r *Reporter) SpecFinished(e SpecResultEvent) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.w != nil {
-		_, _ = fmt.Fprintf(r.w, "SpecFinished %s %v failed=%v\n", e.Name, e.Path, e.Failed)
+		_, _ = fmt.Fprintf(r.w, "SpecFinished %s %v failed=%v duration=%s\n", e.Name, e.Path, e.Failed, e.Duration)
 	}
 }
 

--- a/report/reporter_test.go
+++ b/report/reporter_test.go
@@ -1,0 +1,27 @@
+package report
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestReporterPrintsDuration proves the reference text Reporter surfaces SpecResultEvent.Duration
+// and SuiteEndEvent.Duration in its output, not just the fields that existed before this PR.
+func TestReporterPrintsDuration(t *testing.T) {
+	var buf strings.Builder
+	r := New(&buf)
+
+	r.SuiteStarted(SuiteStartEvent{Name: "Suite"})
+	r.SpecStarted(SpecStartEvent{Name: "spec"})
+	r.SpecFinished(SpecResultEvent{SpecStartEvent: SpecStartEvent{Name: "spec"}, Duration: 5 * time.Millisecond})
+	r.SuiteFinished(SuiteEndEvent{Name: "Suite", Duration: 5 * time.Millisecond})
+
+	out := buf.String()
+	if !strings.Contains(out, "SpecFinished spec [] failed=false duration=5ms") {
+		t.Fatalf("expected SpecFinished line to include duration=5ms, got %q", out)
+	}
+	if !strings.Contains(out, "SuiteFinished Suite duration=5ms") {
+		t.Fatalf("expected SuiteFinished line to include duration=5ms, got %q", out)
+	}
+}

--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -180,11 +180,13 @@ func (s *CompiledSuite) run(tb testing.TB, runCtx context.Context) []proposalCon
 	if name == "" {
 		name = backend.Name()
 	}
-	s.Reporter.SuiteStarted(report.SuiteStartEvent{Name: name, Time: time.Now()})
+	suiteStart := time.Now()
+	s.Reporter.SuiteStarted(report.SuiteStartEvent{Name: name, Time: suiteStart})
 	results := runPlanFlatNoSubtests(runCtx, backend, counter, s.Plan)
 	s.Reporter.SuiteFinished(report.SuiteEndEvent{
 		Name:        name,
 		Time:        time.Now(),
+		Duration:    time.Since(suiteStart),
 		TotalSpecs:  counter.total,
 		FailedSpecs: counter.failed,
 	})
@@ -313,7 +315,7 @@ func reportSpecFinished(rep report.EventReporter, start report.SpecStartEvent, f
 	if rep == nil {
 		return
 	}
-	rep.SpecFinished(report.SpecResultEvent{SpecStartEvent: start, Failed: failed})
+	rep.SpecFinished(report.SpecResultEvent{SpecStartEvent: start, Failed: failed, Duration: time.Since(start.Time)})
 }
 
 // runProgram executes one spec's instructions directly in the caller's goroutine (the default,

--- a/specs/execution_plan_reporter_test.go
+++ b/specs/execution_plan_reporter_test.go
@@ -3,6 +3,7 @@ package specs
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pablogore/go-specs/report"
 )
@@ -169,6 +170,37 @@ func TestDescribeWithReporterStopsAtFirstFailingCandidate(t *testing.T) {
 	}
 	if len(rep.suiteFinished) != 1 || rep.suiteFinished[0].FailedSpecs != 1 {
 		t.Fatalf("expected exactly one FailedSpecs, got %+v", rep.suiteFinished)
+	}
+}
+
+// TestDescribeWithReporterRecordsSpecAndSuiteDuration proves SpecFinished.Duration and
+// SuiteFinished.Duration measure real elapsed time, not a placeholder zero value: a spec that
+// deliberately sleeps reports a Duration at least as long as the sleep, and the enclosing suite's
+// Duration is at least the slept spec's. It also pins down the invariant Duration depends on:
+// SpecFinished.SpecStartEvent must be the exact event SpecStarted sent, not one rebuilt with
+// time.Now() at finish time — asserted here via the Time fields matching exactly.
+func TestDescribeWithReporterRecordsSpecAndSuiteDuration(t *testing.T) {
+	const sleep = 20 * time.Millisecond
+	rep := &recordingReporter{}
+	DescribeWithReporter(t, "DurationSuite", rep, func(s *Spec) {
+		s.It("slow", func(ctx *Context) { time.Sleep(sleep) })
+	})
+
+	if len(rep.specStarted) != 1 || len(rep.specFinished) != 1 {
+		t.Fatalf("expected one SpecStarted/SpecFinished pair, got started=%+v finished=%+v", rep.specStarted, rep.specFinished)
+	}
+	started, finished := rep.specStarted[0], rep.specFinished[0]
+	if !finished.Time.Equal(started.Time) {
+		t.Fatalf("expected SpecFinished.SpecStartEvent to be the exact SpecStarted event, got start=%v finish=%v", started.Time, finished.Time)
+	}
+	if finished.Duration < sleep {
+		t.Fatalf("expected spec Duration >= %v (the spec slept that long), got %v", sleep, finished.Duration)
+	}
+	if len(rep.suiteFinished) != 1 {
+		t.Fatalf("expected one SuiteFinished, got %+v", rep.suiteFinished)
+	}
+	if end := rep.suiteFinished[0]; end.Duration < sleep {
+		t.Fatalf("expected suite Duration >= %v (it wraps the slow spec), got %v", sleep, end.Duration)
 	}
 }
 

--- a/specs/runner.go
+++ b/specs/runner.go
@@ -70,7 +70,7 @@ func (o *reporterObserver) specFinished(start report.SpecStartEvent, failed bool
 	if failed {
 		o.failed++
 	}
-	o.rep.SpecFinished(report.SpecResultEvent{SpecStartEvent: start, Failed: failed})
+	o.rep.SpecFinished(report.SpecResultEvent{SpecStartEvent: start, Failed: failed, Duration: time.Since(start.Time)})
 }
 
 var _ specExecutionObserver = (*reporterObserver)(nil)
@@ -108,11 +108,13 @@ func (r *Runner) Run(tb testing.TB) {
 	}
 	obs := &reporterObserver{rep: r.Reporter}
 	ctx.execObserver = obs
-	r.Reporter.SuiteStarted(report.SuiteStartEvent{Name: name, Time: time.Now()})
+	suiteStart := time.Now()
+	r.Reporter.SuiteStarted(report.SuiteStartEvent{Name: name, Time: suiteStart})
 	runGroups(ctx, r.program.Groups)
 	r.Reporter.SuiteFinished(report.SuiteEndEvent{
 		Name:        name,
 		Time:        time.Now(),
+		Duration:    time.Since(suiteStart),
 		TotalSpecs:  obs.total,
 		FailedSpecs: obs.failed,
 	})

--- a/specs/runner_reporter_test.go
+++ b/specs/runner_reporter_test.go
@@ -3,6 +3,7 @@ package specs
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/pablogore/go-specs/report"
 )
@@ -46,6 +47,74 @@ func TestRunnerWithReporterEmitsSuiteAndSpecEvents(t *testing.T) {
 	end := rep.suiteFinished[0]
 	if end.Name != "Suite" || end.TotalSpecs != 2 || end.FailedSpecs != 1 {
 		t.Fatalf("expected Suite TotalSpecs=2 FailedSpecs=1, got %+v", end)
+	}
+}
+
+// TestRunnerWithReporterRecordsSpecAndSuiteDuration proves SpecFinished.Duration and
+// SuiteFinished.Duration measure real elapsed time (not a placeholder zero), and that
+// SpecFinished.SpecStartEvent is the exact event SpecStarted sent — the invariant Duration depends
+// on, since it's computed from that event's Time, not reconstructed at finish time.
+func TestRunnerWithReporterRecordsSpecAndSuiteDuration(t *testing.T) {
+	const sleep = 20 * time.Millisecond
+	rep := &recordingReporter{}
+	prog := BuildProgram(func(b *Builder) {
+		b.Describe("Suite", func() {
+			b.It("slow", func(ctx *Context) { time.Sleep(sleep) })
+		})
+	})
+
+	NewRunnerWithReporter(prog, "Suite", rep).Run(t)
+
+	if len(rep.specStarted) != 1 || len(rep.specFinished) != 1 {
+		t.Fatalf("expected one SpecStarted/SpecFinished pair, got started=%+v finished=%+v", rep.specStarted, rep.specFinished)
+	}
+	started, finished := rep.specStarted[0], rep.specFinished[0]
+	if !finished.Time.Equal(started.Time) {
+		t.Fatalf("expected SpecFinished.SpecStartEvent to be the exact SpecStarted event, got start=%v finish=%v", started.Time, finished.Time)
+	}
+	if finished.Duration < sleep {
+		t.Fatalf("expected spec Duration >= %v (the spec slept that long), got %v", sleep, finished.Duration)
+	}
+	if len(rep.suiteFinished) != 1 {
+		t.Fatalf("expected one SuiteFinished, got %+v", rep.suiteFinished)
+	}
+	if end := rep.suiteFinished[0]; end.Duration < sleep {
+		t.Fatalf("expected suite Duration >= %v (it wraps the slow spec), got %v", sleep, end.Duration)
+	}
+}
+
+// TestParallelStepWithObserverRecordsPerGoroutineDuration proves each ItParallel spec's Duration is
+// measured against its own goroutine's started event, not shared or reused across specs: only the
+// deliberately slow spec reports a Duration at least as long as the sleep, the fast siblings don't.
+func TestParallelStepWithObserverRecordsPerGoroutineDuration(t *testing.T) {
+	const sleep = 20 * time.Millisecond
+	rep := &recordingReporter{}
+	obs := &reporterObserver{rep: rep}
+	backend := &capturingBackend{}
+	ctx := &Context{backend: backend, execObserver: obs}
+
+	run := parallelStep([]step{
+		runAll([]step{func(*Context) {}}),
+		runAll([]step{func(*Context) { time.Sleep(sleep) }}),
+		runAll([]step{func(*Context) {}}),
+	}, []string{"fast1", "slow", "fast2"})
+	run(ctx)
+
+	if len(rep.specFinished) != 3 {
+		t.Fatalf("expected three SpecFinished, got %+v", rep.specFinished)
+	}
+	byName := map[string]time.Duration{}
+	for _, e := range rep.specFinished {
+		byName[e.Name] = e.Duration
+	}
+	if d, ok := byName["slow"]; !ok || d < sleep {
+		t.Fatalf("expected 'slow' Duration >= %v, got %v (all: %+v)", sleep, d, byName)
+	}
+	if d, ok := byName["fast1"]; !ok || d >= sleep {
+		t.Fatalf("expected 'fast1' Duration < %v, got %v (all: %+v)", sleep, d, byName)
+	}
+	if d, ok := byName["fast2"]; !ok || d >= sleep {
+		t.Fatalf("expected 'fast2' Duration < %v, got %v (all: %+v)", sleep, d, byName)
 	}
 }
 

--- a/specs/runner_reporter_test.go
+++ b/specs/runner_reporter_test.go
@@ -84,8 +84,13 @@ func TestRunnerWithReporterRecordsSpecAndSuiteDuration(t *testing.T) {
 }
 
 // TestParallelStepWithObserverRecordsPerGoroutineDuration proves each ItParallel spec's Duration is
-// measured against its own goroutine's started event, not shared or reused across specs: only the
-// deliberately slow spec reports a Duration at least as long as the sleep, the fast siblings don't.
+// measured against its own goroutine's started event, not shared or reused across specs.
+//
+// This only asserts a lower bound on the deliberately slow spec and that every spec's reported
+// SpecFinished.SpecStartEvent.Time matches its own SpecStarted.Time exactly — never an upper bound
+// on the fast siblings. An upper-bound/exact-timing assertion on "fast1"/"fast2" (e.g. Duration <
+// sleep) would be flaky under a loaded CI runner, where even an empty spec body can take longer than
+// a short sleep to get scheduled between SpecStarted and SpecFinished.
 func TestParallelStepWithObserverRecordsPerGoroutineDuration(t *testing.T) {
 	const sleep = 20 * time.Millisecond
 	rep := &recordingReporter{}
@@ -100,21 +105,24 @@ func TestParallelStepWithObserverRecordsPerGoroutineDuration(t *testing.T) {
 	}, []string{"fast1", "slow", "fast2"})
 	run(ctx)
 
-	if len(rep.specFinished) != 3 {
-		t.Fatalf("expected three SpecFinished, got %+v", rep.specFinished)
+	if len(rep.specStarted) != 3 || len(rep.specFinished) != 3 {
+		t.Fatalf("expected three SpecStarted/SpecFinished, got started=%+v finished=%+v", rep.specStarted, rep.specFinished)
 	}
-	byName := map[string]time.Duration{}
+	startByName := map[string]time.Time{}
+	for _, e := range rep.specStarted {
+		startByName[e.Name] = e.Time
+	}
 	for _, e := range rep.specFinished {
-		byName[e.Name] = e.Duration
-	}
-	if d, ok := byName["slow"]; !ok || d < sleep {
-		t.Fatalf("expected 'slow' Duration >= %v, got %v (all: %+v)", sleep, d, byName)
-	}
-	if d, ok := byName["fast1"]; !ok || d >= sleep {
-		t.Fatalf("expected 'fast1' Duration < %v, got %v (all: %+v)", sleep, d, byName)
-	}
-	if d, ok := byName["fast2"]; !ok || d >= sleep {
-		t.Fatalf("expected 'fast2' Duration < %v, got %v (all: %+v)", sleep, d, byName)
+		start, ok := startByName[e.Name]
+		if !ok || !e.Time.Equal(start) {
+			t.Fatalf("expected %q's SpecFinished.SpecStartEvent to be its own SpecStarted event, got start=%v finish=%v", e.Name, start, e.Time)
+		}
+		if e.Duration < 0 {
+			t.Fatalf("expected non-negative Duration for %q, got %v", e.Name, e.Duration)
+		}
+		if e.Name == "slow" && e.Duration < sleep {
+			t.Fatalf("expected 'slow' Duration >= %v, got %v", sleep, e.Duration)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

Part of #13. The event schema (`report/events.go`) has no `Duration` on `SpecResultEvent`/`SuiteEndEvent`, only a start `Time`. Any structured reporter (JUnit XML's `time="..."` attributes, JSON reporters) needs real elapsed time per spec and per suite, and it can't be reconstructed after the fact without a start/end pair.

Issue #13 originally asked for three things at once: `Duration`, a `Skipped` state, and a structured `Message`/`Output` split for failure detail. Splitting this up (same pattern as #12-A/#12-B): this PR is Duration only.

## Why the other two stay out of this PR

- **Skipped**: there is no runtime "skipped" concept today. `Skip`/`SkipIt` are compile-time only — a skipped spec is never emitted into the compiled `Program`/`ExecutionPlan` at all (`specs/skip.go`). Adding a `Skipped bool` field now would leave it permanently `false`, since nothing would ever set it — the same "declared but not wired" gap #12 fixed for `EventReporter` itself. Making it real requires deciding whether a skipped spec keeps identity through compilation and counts toward `TotalSpecs`/`SkippedSpecs` — an execution-semantics decision, not a schema change. Left for a separate issue.
- **Message/Output**: today a spec's failure text goes straight to the test backend (`t.Errorf`/`t.Fatalf`, or `parallelBackend.results[i]` for `ItParallel`) and is never captured anywhere the reporter path can read (confirmed: no producer sets `SpecResultEvent.Message` today either — it's already a dead field). Populating it meaningfully needs a defined place for a spec's structured result/diagnostics to live before backend and reporter both consume it — a design question, not an additive field. Left for a separate issue.

## Fix

- `report/events.go`: added `Duration time.Duration` to `SpecResultEvent` and `SuiteEndEvent`. Purely additive — no other field changed shape.
- Both reporting choke points now compute real `Duration`:
  - `specs/execution_plan.go`: `reportSpecFinished` sets `Duration: time.Since(start.Time)`; `CompiledSuite.run` captures `suiteStart` once and sets `SuiteFinished.Duration` from it.
  - `specs/runner.go`: `reporterObserver.specFinished` sets `Duration: time.Since(start.Time)`; `Runner.Run` captures `suiteStart` once and sets `SuiteFinished.Duration` from it. `RunShardWithReporter` gets this for free — it delegates to `Runner.Run`.
- `ItParallel` (`program.go`'s `parallelStep`) needed no changes: each goroutine already captures its own `started` event before running its spec (from #12-B), so per-spec `Duration` falls out naturally from the same `reporterObserver.specFinished` choke point — no shared/reused start time across parallel specs.
- Codified the invariant `Duration` depends on: `SpecResultEvent`'s doc comment now states that its embedded `SpecStartEvent` must always be the exact event `SpecStarted` sent, never reconstructed with `time.Now()` at finish time. Verified both choke points already hold this (the execution_plan.go path was fixed for this in #70's follow-up `4f02e01`; the runner.go/ItParallel paths never had the bug) — no behavior change needed, just locked in with an explicit test per path.
- `report/reporter.go` (the reference text `Reporter`): `SpecFinished`/`SuiteFinished` output now includes `duration=%s`, so the one shipped `EventReporter` implementation actually surfaces the new field instead of leaving it print-invisible.

## Tests

- `specs/execution_plan_reporter_test.go`: new `TestDescribeWithReporterRecordsSpecAndSuiteDuration` — a spec that sleeps 20ms reports `Duration >= 20ms`, the wrapping suite's `Duration >= 20ms` too, and `SpecFinished.SpecStartEvent.Time` matches `SpecStarted`'s exactly.
- `specs/runner_reporter_test.go`:
  - `TestRunnerWithReporterRecordsSpecAndSuiteDuration` — same shape, for the `Program`/`Runner` model.
  - `TestParallelStepWithObserverRecordsPerGoroutineDuration` — three `ItParallel` specs, only the middle one sleeps; asserts its `Duration >= 20ms` and, for all three, that `SpecFinished.SpecStartEvent.Time` matches that spec's own `SpecStarted.Time` exactly — proving each goroutine's `Duration` is measured against its own start, not a shared one, without an upper-bound timing assert on the fast siblings (flaky under a loaded CI runner).
- `report/reporter_test.go` (new file — the package had no tests before): `TestReporterPrintsDuration` locks in the new `duration=...` output on both `SpecFinished` and `SuiteFinished` lines.
- All new assertions use a real sleep as a lower bound (`Duration >= sleep`), never an exact/upper-bound timing assertion, to avoid flakiness.

## Validation

- `gofmt -l` on touched files — clean
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./...` — clean (20 packages ok)
- `go test ./... -race -count=1` — clean
- `make build` — clean
- `make lint` — 0 issues

## Relationship

Part of #13. This is "#13-A: Duration". #13 stays open for the remaining two pieces: a separate issue for `Skipped` semantics (deciding whether/how a skipped spec keeps identity through compilation and counts in the report), and a separate issue for structured failure/output capture (defining a common per-spec result/diagnostics representation before `Message`/`Output` can be populated for real).
