### PR TITLE
feat(specs): report Builder/Program/Runner skipped specs (#13-B)

### DIFF
--- a/report/events.go
+++ b/report/events.go
@@ -10,11 +10,12 @@ type SuiteStartEvent struct {
 
 // SuiteEndEvent is emitted when a suite finishes executing.
 type SuiteEndEvent struct {
-	Name        string
-	Time        time.Time
-	Duration    time.Duration // elapsed time between this suite's SuiteStartEvent and this event
-	TotalSpecs  int
-	FailedSpecs int
+	Name         string
+	Time         time.Time
+	Duration     time.Duration // elapsed time between this suite's SuiteStartEvent and this event
+	TotalSpecs   int           // passed + failed + skipped
+	FailedSpecs  int
+	SkippedSpecs int
 }
 
 // SpecStartEvent captures the start of an individual spec (It/Then).
@@ -32,7 +33,8 @@ type SpecStartEvent struct {
 type SpecResultEvent struct {
 	SpecStartEvent
 	Failed   bool
-	Duration time.Duration // elapsed time between SpecStartEvent.Time and this event
+	Skipped  bool          // true for a compile-time SkipIt/Skip spec: body never ran, Duration is 0, Failed is always false
+	Duration time.Duration // elapsed time between SpecStartEvent.Time and this event; always 0 when Skipped
 	Message  string
 }
 

--- a/report/reporter.go
+++ b/report/reporter.go
@@ -36,7 +36,7 @@ func (r *Reporter) SuiteFinished(e SuiteEndEvent) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.w != nil {
-		_, _ = fmt.Fprintf(r.w, "SuiteFinished %s duration=%s\n", e.Name, e.Duration)
+		_, _ = fmt.Fprintf(r.w, "SuiteFinished %s duration=%s skipped=%d\n", e.Name, e.Duration, e.SkippedSpecs)
 	}
 	r.path = nil
 }
@@ -55,7 +55,7 @@ func (r *Reporter) SpecFinished(e SpecResultEvent) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.w != nil {
-		_, _ = fmt.Fprintf(r.w, "SpecFinished %s %v failed=%v duration=%s\n", e.Name, e.Path, e.Failed, e.Duration)
+		_, _ = fmt.Fprintf(r.w, "SpecFinished %s %v failed=%v skipped=%v duration=%s\n", e.Name, e.Path, e.Failed, e.Skipped, e.Duration)
 	}
 }
 

--- a/report/reporter_test.go
+++ b/report/reporter_test.go
@@ -18,10 +18,30 @@ func TestReporterPrintsDuration(t *testing.T) {
 	r.SuiteFinished(SuiteEndEvent{Name: "Suite", Duration: 5 * time.Millisecond})
 
 	out := buf.String()
-	if !strings.Contains(out, "SpecFinished spec [] failed=false duration=5ms") {
+	if !strings.Contains(out, "SpecFinished spec [] failed=false skipped=false duration=5ms") {
 		t.Fatalf("expected SpecFinished line to include duration=5ms, got %q", out)
 	}
-	if !strings.Contains(out, "SuiteFinished Suite duration=5ms") {
+	if !strings.Contains(out, "SuiteFinished Suite duration=5ms skipped=0") {
 		t.Fatalf("expected SuiteFinished line to include duration=5ms, got %q", out)
+	}
+}
+
+// TestReporterPrintsSkipped proves the reference text Reporter surfaces SpecResultEvent.Skipped and
+// SuiteEndEvent.SkippedSpecs, not just the fields that existed before this PR.
+func TestReporterPrintsSkipped(t *testing.T) {
+	var buf strings.Builder
+	r := New(&buf)
+
+	r.SuiteStarted(SuiteStartEvent{Name: "Suite"})
+	r.SpecStarted(SpecStartEvent{Name: "spec"})
+	r.SpecFinished(SpecResultEvent{SpecStartEvent: SpecStartEvent{Name: "spec"}, Skipped: true})
+	r.SuiteFinished(SuiteEndEvent{Name: "Suite", SkippedSpecs: 1})
+
+	out := buf.String()
+	if !strings.Contains(out, "SpecFinished spec [] failed=false skipped=true duration=0s") {
+		t.Fatalf("expected SpecFinished line to include skipped=true, got %q", out)
+	}
+	if !strings.Contains(out, "SuiteFinished Suite duration=0s skipped=1") {
+		t.Fatalf("expected SuiteFinished line to include skipped=1, got %q", out)
 	}
 }

--- a/specs/builder.go
+++ b/specs/builder.go
@@ -155,10 +155,12 @@ func (b *Builder) It(name string, fn interface{}) {
 	})
 }
 
-// SkipIt registers a spec that is skipped at compile time (no steps emitted).
+// SkipIt registers a spec that is skipped at compile time: fn is never compiled into any step (it
+// never runs, so it doesn't need to be a valid func — see Skip), but name is preserved so the
+// compiled Program can still report the spec's identity as skipped. See finalize.
 func (b *Builder) SkipIt(name string, fn func(*Context)) {
 	b.ensureScope()
-	b.pending = append(b.pending, specItem{kind: kindSkip})
+	b.pending = append(b.pending, specItem{kind: kindSkip, name: name})
 }
 
 // FIt registers a focused spec. If any spec is focused, only focused specs are compiled into the program.
@@ -209,7 +211,18 @@ func (b *Builder) hookKey() string {
 	return string(buf)
 }
 
-// finalize builds program.Groups from pending: focus filter, drop skip, coalesce same-hook specs, group parallel.
+// finalize builds program.Groups from pending: focus filter, coalesce same-hook specs, group
+// parallel, and attach skip names to whichever group they end up nearest to.
+//
+// A kindSkip item never becomes a step (it has no before/after/spec — SkipIt never captures them),
+// so it can't form its own execution unit the way a real spec does. Instead its name is buffered in
+// pendingSkips and attached to the next group finalize creates or appends to (normal/focus/parallel
+// alike), then the buffer is cleared. This deliberately does NOT give skip its own group: doing so
+// would insert a group boundary between two coalesced same-hookKey specs (e.g. It("a"), SkipIt("b"),
+// It("c") in the same Describe), which would make their shared before/after run twice instead of
+// once — see TestProgram_SkipRemoval / TestSkipRemovesSpecs, which pin the coalesced-group-count
+// invariant this must not break. Any pendingSkips left over once every item is processed (trailing
+// skips, or an all-skip Describe) become their own skip-only group at the end.
 func (b *Builder) finalize() {
 	items := b.pending
 	if b.hasFocus {
@@ -223,9 +236,11 @@ func (b *Builder) finalize() {
 	}
 	var groups []group
 	curIdx := -1
+	var pendingSkips []string
 	for i := 0; i < len(items); i++ {
 		it := items[i]
 		if it.kind == kindSkip {
+			pendingSkips = append(pendingSkips, it.name)
 			continue
 		}
 		if it.kind == kindParallel {
@@ -242,7 +257,8 @@ func (b *Builder) finalize() {
 			// which reports each real ItParallel spec itself (via ctx.execObserver) as it runs on
 			// its own goroutine. Runner.Run's sequential per-spec reporting only fires when names
 			// is populated, so it correctly stays out of the way here instead of double-reporting.
-			groups = append(groups, group{specs: []step{parallelStep(parSteps, parNames)}})
+			groups = append(groups, group{specs: []step{parallelStep(parSteps, parNames)}, skipped: pendingSkips})
+			pendingSkips = nil
 			i = j - 1
 			continue
 		}
@@ -250,10 +266,16 @@ func (b *Builder) finalize() {
 		if curIdx >= 0 && groups[curIdx].hookKey == it.hookKey {
 			groups[curIdx].specs = append(groups[curIdx].specs, it.spec)
 			groups[curIdx].names = append(groups[curIdx].names, it.name)
+			groups[curIdx].skipped = append(groups[curIdx].skipped, pendingSkips...)
+			pendingSkips = nil
 		} else {
-			groups = append(groups, group{before: it.before, specs: []step{it.spec}, names: []string{it.name}, after: it.after, hookKey: it.hookKey})
+			groups = append(groups, group{before: it.before, specs: []step{it.spec}, names: []string{it.name}, after: it.after, hookKey: it.hookKey, skipped: pendingSkips})
+			pendingSkips = nil
 			curIdx = len(groups) - 1
 		}
+	}
+	if len(pendingSkips) > 0 {
+		groups = append(groups, group{skipped: pendingSkips})
 	}
 	b.program.Groups = groups
 }

--- a/specs/context.go
+++ b/specs/context.go
@@ -70,6 +70,7 @@ func (c *Context) Reset(backend testBackend) {
 	c.T = nil
 	c.coverage = nil
 	c.failed = false
+	c.failFast = false
 	c.execObserver = nil
 	if backend != nil {
 		// runnableBackend wraps the subtest T; unwrap so ctx.T points to the current subtest.

--- a/specs/context_test.go
+++ b/specs/context_test.go
@@ -1,0 +1,20 @@
+package specs
+
+import "testing"
+
+// TestContextResetClearsFailFast pins a fix for a Context pool leak: contextPool reuses *Context
+// across unrelated Runner.Run calls, and failFast must not survive a Reset the way it used to.
+// Without this, a Runner{FailFast: true} in one test could leak failFast=true into a later,
+// unrelated Runner{FailFast: false} that happened to draw the same pooled Context — silently
+// dropping every group after a failing spec, including a trailing skip-only group, with no
+// FailFast requested at all.
+func TestContextResetClearsFailFast(t *testing.T) {
+	ctx := &Context{}
+	ctx.SetFailFast(true)
+
+	ctx.Reset(nil)
+
+	if ctx.failFast {
+		t.Fatal("expected Reset to clear failFast, but it stayed true")
+	}
+}

--- a/specs/program.go
+++ b/specs/program.go
@@ -19,12 +19,19 @@ type step func(*Context)
 // names holds one entry per group.specs entry (SpecStartEvent.Name), or is left nil for a group
 // whose single spec is a parallelStep closure: that closure reports each real spec itself (see
 // parallelStep), so Runner.Run's sequential per-spec reporting must not also wrap it.
+//
+// skipped holds the names of compile-time-skipped specs (SkipIt/Skip) that finalize attached to
+// this group — see builder.go's finalize for why a skip can't have its own group. They carry no
+// before/spec/after of their own and never touch this group's before/after; Runner reports them
+// (SpecStarted+SpecFinished{Skipped:true}, no body run) independently of whether this group's real
+// specs run at all.
 type group struct {
 	before  []step
 	specs   []step
 	names   []string
 	after   []step
 	hookKey string
+	skipped []string
 }
 
 // specName returns names[i], or "" when names doesn't cover index i (an unnamed spec, e.g. from
@@ -44,6 +51,11 @@ func specName(names []string, i int) string {
 type specExecutionObserver interface {
 	specStarted(name string) report.SpecStartEvent
 	specFinished(start report.SpecStartEvent, failed bool)
+	// specSkipped reports one compile-time-skipped spec (SkipIt/Skip): a single SpecStarted +
+	// SpecFinished{Skipped: true} pair, with no body ever run. Only Runner.Run's sequential group
+	// execution calls this (see runner.go's reportSkipped) — ItParallel/parallelStep has no skip
+	// concept, so it never needs it.
+	specSkipped(name string)
 }
 
 // Program is a compiled execution program. Groups run in order; within a group: before once, all specs, after once (reverse).

--- a/specs/runner.go
+++ b/specs/runner.go
@@ -45,14 +45,15 @@ func NewRunnerWithReporter(program *Program, name string, rep report.EventReport
 // reporterObserver adapts a report.EventReporter to specExecutionObserver, serializing calls with a
 // mutex: a parallel group's goroutines call specStarted/specFinished concurrently, and not every
 // EventReporter implementation can be assumed to be concurrency-safe on its own — the framework
-// serializes on its behalf instead of expanding EventReporter's contract to require it. total/failed
-// tally every reported spec (sequential and parallel alike, since both paths share one instance via
-// ctx.execObserver) for the run's SuiteEndEvent.
+// serializes on its behalf instead of expanding EventReporter's contract to require it. total/failed/
+// skipped tally every reported spec (sequential and parallel alike, since both paths share one
+// instance via ctx.execObserver) for the run's SuiteEndEvent. total counts passed+failed+skipped.
 type reporterObserver struct {
-	mu     sync.Mutex
-	rep    report.EventReporter
-	total  int
-	failed int
+	mu      sync.Mutex
+	rep     report.EventReporter
+	total   int
+	failed  int
+	skipped int
 }
 
 func (o *reporterObserver) specStarted(name string) report.SpecStartEvent {
@@ -71,6 +72,20 @@ func (o *reporterObserver) specFinished(start report.SpecStartEvent, failed bool
 		o.failed++
 	}
 	o.rep.SpecFinished(report.SpecResultEvent{SpecStartEvent: start, Failed: failed, Duration: time.Since(start.Time)})
+}
+
+// specSkipped reports a compile-time-skipped spec: SpecStarted immediately followed by
+// SpecFinished{Skipped: true}, reusing the exact same SpecStartEvent for both (same invariant
+// specStarted/specFinished hold for a real spec) — Duration is left at its zero value, since no
+// body ever ran between them, and Failed is always false.
+func (o *reporterObserver) specSkipped(name string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	e := report.SpecStartEvent{Name: name, Time: time.Now()}
+	o.rep.SpecStarted(e)
+	o.total++
+	o.skipped++
+	o.rep.SpecFinished(report.SpecResultEvent{SpecStartEvent: e, Skipped: true})
 }
 
 var _ specExecutionObserver = (*reporterObserver)(nil)
@@ -112,11 +127,12 @@ func (r *Runner) Run(tb testing.TB) {
 	r.Reporter.SuiteStarted(report.SuiteStartEvent{Name: name, Time: suiteStart})
 	runGroups(ctx, r.program.Groups)
 	r.Reporter.SuiteFinished(report.SuiteEndEvent{
-		Name:        name,
-		Time:        time.Now(),
-		Duration:    time.Since(suiteStart),
-		TotalSpecs:  obs.total,
-		FailedSpecs: obs.failed,
+		Name:         name,
+		Time:         time.Now(),
+		Duration:     time.Since(suiteStart),
+		TotalSpecs:   obs.total,
+		FailedSpecs:  obs.failed,
+		SkippedSpecs: obs.skipped,
 	})
 }
 
@@ -150,9 +166,15 @@ func runGroups(ctx *Context, groups []group) {
 // t.Fatal/FailNow (runtime.Goexit unwinds through this defer same as a panic would), after gets a
 // chance to clean up whatever before did set up. Each after hook is recovered individually, so one
 // panicking after hook doesn't stop its siblings from attempting to run.
+//
+// g.skipped is reported first, before before even runs: those names carry no before/after of their
+// own (see builder.go's finalize), so their identity as skipped must not depend on whether this
+// group's unrelated before hook — which they were only attached to for compilation reasons —
+// succeeds, fails, or FailFast ends up skipping the rest of this group.
 func runGroup(ctx *Context, g *group) {
 	defer runAfterRecovered(ctx, g.after)
 
+	reportSkipped(ctx, g)
 	if !runBeforeRecovered(ctx, g.before) {
 		return
 	}
@@ -160,6 +182,20 @@ func runGroup(ctx *Context, g *group) {
 		return
 	}
 	runSpecsRecovered(ctx, g)
+}
+
+// reportSkipped reports each of g.skipped as its own SpecStarted/SpecFinished{Skipped: true} pair.
+// A skipped spec was never compiled into a step (see builder.go's finalize), so there is nothing to
+// run for it here — only its identity is reported, via ctx.execObserver same as any other spec. A
+// nil execObserver (no Reporter attached) means nothing happens at all, same as any unreported spec.
+func reportSkipped(ctx *Context, g *group) {
+	obs := ctx.execObserver
+	if obs == nil {
+		return
+	}
+	for _, name := range g.skipped {
+		obs.specSkipped(name)
+	}
 }
 
 // runBeforeRecovered runs a group's before hooks in order. Returns false if a panic stopped setup

--- a/specs/runner_reporter_test.go
+++ b/specs/runner_reporter_test.go
@@ -290,4 +290,164 @@ func TestRunnerNilReporterNoObserver(t *testing.T) {
 	}
 }
 
+// TestRunnerWithReporterReportsSkippedSpec proves a SkipIt spec is reported as its own
+// SpecStarted/SpecFinished{Skipped: true, Failed: false} pair, with its name preserved and its body
+// never run — and that it's counted in SuiteEndEvent.TotalSpecs/SkippedSpecs alongside real specs.
+func TestRunnerWithReporterReportsSkippedSpec(t *testing.T) {
+	var ranSkipped bool
+	rep := &recordingReporter{}
+	prog := BuildProgram(func(b *Builder) {
+		b.Describe("Suite", func() {
+			b.It("a", func(ctx *Context) {})
+			b.SkipIt("b", func(ctx *Context) { ranSkipped = true })
+			b.It("c", func(ctx *Context) {})
+		})
+	})
+
+	NewRunnerWithReporter(prog, "Suite", rep).Run(t)
+
+	if ranSkipped {
+		t.Fatal("expected the skipped spec's body to never run")
+	}
+	if len(rep.specStarted) != 3 || len(rep.specFinished) != 3 {
+		t.Fatalf("expected three SpecStarted/SpecFinished (a, b, c), got started=%+v finished=%+v", rep.specStarted, rep.specFinished)
+	}
+	var skip *report.SpecResultEvent
+	for i := range rep.specFinished {
+		if rep.specFinished[i].Name == "b" {
+			skip = &rep.specFinished[i]
+		}
+	}
+	if skip == nil {
+		t.Fatalf("expected a SpecFinished named %q, got %+v", "b", rep.specFinished)
+	}
+	if !skip.Skipped {
+		t.Errorf("expected Skipped=true for %q, got %+v", "b", *skip)
+	}
+	if skip.Failed {
+		t.Errorf("expected Failed=false for a skipped spec, got %+v", *skip)
+	}
+	if skip.Duration != 0 {
+		t.Errorf("expected Duration=0 for a skipped spec (no body ran), got %v", skip.Duration)
+	}
+	if len(rep.suiteFinished) != 1 {
+		t.Fatalf("expected one SuiteFinished, got %+v", rep.suiteFinished)
+	}
+	end := rep.suiteFinished[0]
+	if end.TotalSpecs != 3 || end.FailedSpecs != 0 || end.SkippedSpecs != 1 {
+		t.Fatalf("expected TotalSpecs=3 (a,b,c) FailedSpecs=0 SkippedSpecs=1, got %+v", end)
+	}
+}
+
+// TestRunnerWithReporterCountsMixedPassFailSkip proves TotalSpecs/FailedSpecs/SkippedSpecs combine
+// correctly when a suite mixes a passing, a failing, and a skipped spec — TotalSpecs is the sum of
+// all three categories, not just executed (passed+failed) specs.
+func TestRunnerWithReporterCountsMixedPassFailSkip(t *testing.T) {
+	rep := &recordingReporter{}
+	prog := BuildProgram(func(b *Builder) {
+		b.Describe("Suite", func() {
+			b.It("passes", func(ctx *Context) {})
+			b.It("fails", func(ctx *Context) { ctx.recordFailure() })
+			b.SkipIt("skipped", func(ctx *Context) {})
+		})
+	})
+
+	NewRunnerWithReporter(prog, "Suite", rep).Run(t)
+
+	if len(rep.suiteFinished) != 1 {
+		t.Fatalf("expected one SuiteFinished, got %+v", rep.suiteFinished)
+	}
+	end := rep.suiteFinished[0]
+	if end.TotalSpecs != 3 || end.FailedSpecs != 1 || end.SkippedSpecs != 1 {
+		t.Fatalf("expected TotalSpecs=3 FailedSpecs=1 SkippedSpecs=1, got %+v", end)
+	}
+}
+
+// TestRunnerWithReporterReportsMultipleSkips proves several SkipIt specs in the same suite are each
+// reported individually, by name, not collapsed into one event or one count.
+func TestRunnerWithReporterReportsMultipleSkips(t *testing.T) {
+	rep := &recordingReporter{}
+	prog := BuildProgram(func(b *Builder) {
+		b.Describe("Suite", func() {
+			b.SkipIt("skip1", func(ctx *Context) {})
+			b.It("runs", func(ctx *Context) {})
+			b.SkipIt("skip2", func(ctx *Context) {})
+			b.SkipIt("skip3", func(ctx *Context) {})
+		})
+	})
+
+	NewRunnerWithReporter(prog, "Suite", rep).Run(t)
+
+	var skipNames []string
+	for _, e := range rep.specFinished {
+		if e.Skipped {
+			skipNames = append(skipNames, e.Name)
+		}
+	}
+	sort.Strings(skipNames)
+	want := []string{"skip1", "skip2", "skip3"}
+	if len(skipNames) != len(want) {
+		t.Fatalf("expected skipped names %v, got %v (all finished: %+v)", want, skipNames, rep.specFinished)
+	}
+	for i := range want {
+		if skipNames[i] != want[i] {
+			t.Fatalf("expected skipped names %v, got %v", want, skipNames)
+		}
+	}
+	end := rep.suiteFinished[0]
+	if end.TotalSpecs != 4 || end.SkippedSpecs != 3 {
+		t.Fatalf("expected TotalSpecs=4 SkippedSpecs=3, got %+v", end)
+	}
+}
+
+// TestRunShardWithReporterCountsOnlyShardSkips proves a shard's SuiteEndEvent.SkippedSpecs (and
+// reported SpecFinished{Skipped:true} events) reflect only the skips in groups assigned to that
+// shard, not every skip in the unsharded Program — RunShard/RunShardWithReporter shard whole groups
+// (see scheduler.go), and a group's skipped names travel with it like any other group data, so this
+// is the same "shard describes only what it ran" contract TestRunShardWithReporterCountsOnlyShardSpecs
+// already pins for real specs, extended to skips.
+func TestRunShardWithReporterCountsOnlyShardSkips(t *testing.T) {
+	// shardCount == len(Groups) so shard i gets exactly group i (gi%shardCount==shardIndex), keeping
+	// which skip lands on which shard unambiguous.
+	prog := &Program{Groups: []group{
+		{skipped: []string{"skip-a"}},
+		{specs: []step{func(*Context) {}}, names: []string{"b"}},
+		{skipped: []string{"skip-c"}},
+		{specs: []step{func(*Context) {}}, names: []string{"d"}},
+	}}
+
+	rep := &recordingReporter{}
+	RunShardWithReporter(prog, t, 0, 4, "Shard0", rep)
+
+	if len(rep.specFinished) != 1 || rep.specFinished[0].Name != "skip-a" || !rep.specFinished[0].Skipped {
+		t.Fatalf("expected shard 0 to report exactly skip-a as skipped, got %+v", rep.specFinished)
+	}
+	end := rep.suiteFinished[0]
+	if end.TotalSpecs != 1 || end.SkippedSpecs != 1 {
+		t.Fatalf("expected shard 0 TotalSpecs=1 SkippedSpecs=1 (only skip-a's group), got %+v", end)
+	}
+
+	rep2 := &recordingReporter{}
+	RunShardWithReporter(prog, t, 2, 4, "Shard2", rep2)
+
+	if len(rep2.specFinished) != 1 || rep2.specFinished[0].Name != "skip-c" || !rep2.specFinished[0].Skipped {
+		t.Fatalf("expected shard 2 to report exactly skip-c as skipped, got %+v", rep2.specFinished)
+	}
+	end2 := rep2.suiteFinished[0]
+	if end2.TotalSpecs != 1 || end2.SkippedSpecs != 1 {
+		t.Fatalf("expected shard 2 TotalSpecs=1 SkippedSpecs=1 (only skip-c's group), got %+v", end2)
+	}
+
+	rep3 := &recordingReporter{}
+	RunShardWithReporter(prog, t, 1, 4, "Shard1", rep3)
+
+	if len(rep3.specFinished) != 1 || rep3.specFinished[0].Skipped {
+		t.Fatalf("expected shard 1 (group b) to report zero skips, got %+v", rep3.specFinished)
+	}
+	end3 := rep3.suiteFinished[0]
+	if end3.SkippedSpecs != 0 {
+		t.Fatalf("expected shard 1 SkippedSpecs=0, got %+v", end3)
+	}
+}
+
 var _ report.EventReporter = (*recordingReporter)(nil)

--- a/specs/skip.go
+++ b/specs/skip.go
@@ -1,5 +1,6 @@
-// skip.go provides skipped-spec support. SkipIt and Skip() are compile-time only;
-// skipped specs are not emitted to the program.
+// skip.go provides skipped-spec support. SkipIt and Skip() are compile-time only: a skipped spec's
+// body is never compiled into a step and never runs. Its name is preserved and, with a Reporter
+// attached, reported as skipped (see builder.go's finalize and runner.go's reportSkipped).
 package specs
 
 // Skip returns a SpecFn that marks the spec as skipped. Use with It: b.It("name", specs.Skip(fn)).


### PR DESCRIPTION
## Problem

Issue #13 asks for richer spec results. #13-A (PR #72, merged) added `Duration`. This PR is #13-B: **Skipped semantics**.

`SkipIt`/`Skip` already exist in the `Builder → Program → Runner` DSL, but a skipped spec's name was discarded at compile time and nothing ever reported that it existed — it simply vanished from the suite. There is no way today to know how many specs were skipped, or which ones.

Before writing any code, I checked whether `Spec`/`ExecutionPlan` (the second, independent execution model used by `Describe`/`Paths`/`Sample`/`Explore`) has a Skip concept at all. It doesn't — `Spec.It` only accepts `func(*Context)`, with no skip path. That's a real API boundary, not an accidental gap in wiring, so this PR does not add Skip to `Spec`/`ExecutionPlan` (and therefore not to `Paths`/`Sample`/`Explore` either). A future "Add skip semantics to Spec/ExecutionPlan DSL" issue can pursue that symmetry separately, if wanted.

## Fix

- `SkipIt` now preserves the spec's `name` instead of discarding it.
- `Builder.finalize` buffers pending skip names (`pendingSkips`) as it walks `b.pending`, attaching them to whichever group is created or appended to next (normal, focus, or parallel groups alike), then clears the buffer. This is deliberate: giving a skip its own group would insert a group boundary between two coalesced same-scope specs (e.g. `It("a"), SkipIt("b"), It("c")` in one `Describe`), breaking the existing invariant that same-scope specs share one `before`/`after` run (`TestProgram_SkipRemoval`, `TestSkipRemovesSpecs`). Skip names now ride along with the next group instead, and a trailing skip (or an all-skip `Describe`) becomes its own skip-only group.
- `group` gained a `skipped []string` field. Group-level sharding (`shardProgram`/`RunShardWithReporter`) already shards whole groups, so skip names automatically shard with their group — no extra sharding logic needed.
- `specExecutionObserver` gained `specSkipped(name string)`. `Runner`'s `reportSkipped` calls it directly for each name in `g.skipped`, **before** running the group's `before` hook: `SpecStarted` → `SpecFinished{Skipped: true}`, no body, no hooks. It runs first specifically so a skipped spec's identity is reported regardless of whether the (structurally unrelated) group it was attached to for compilation reasons goes on to succeed, fail, or get cut short by FailFast.
- `SuiteEndEvent` gained `SkippedSpecs int`. Counts: `TotalSpecs = passed + failed + skipped`, `FailedSpecs = failed`, `SkippedSpecs = skipped` — clean JUnit semantics.
- The reference `Reporter`'s text output now includes `skipped=...` for both spec and suite lines.

**Also fixed in this PR:** `Context.Reset` never cleared `failFast` back to `false`. Since `Context` instances are reused via a shared `sync.Pool` across `Runner.Run` calls, a `Runner{FailFast: true}` in one test could leak `failFast=true` into a completely unrelated later `Runner{FailFast: false}` run that happened to draw the same pooled `Context`. That silently dropped every group after a failing spec — including a trailing skip-only group — with no `FailFast` requested at all. This surfaced as a flaky failure in one of the new tests below; it's a pre-existing bug, not introduced by this change, but it directly undermines skip reporting's correctness so it's fixed here rather than filed separately.

## Out of scope

- `Spec`/`ExecutionPlan`, and therefore `Paths`/`Sample`/`Explore` — no Skip concept there today; adding one is new API, not reporter wiring.
- `Message`/`Output` capture — deferred to #13-C.
- Changing the public `Skip`/`SkipIt` signatures beyond preserving the name they already accept.
- Unifying `Builder`/`Program` and `Spec`/`ExecutionPlan`.

## Tests

- Name preserved for a skipped spec; body never runs.
- `SpecStarted` → `SpecFinished` with `Skipped: true`, `Failed: false`.
- Mixed pass/fail/skip suite: `TotalSpecs`/`FailedSpecs`/`SkippedSpecs` combine correctly.
- Multiple skips in one suite, each reported individually by name.
- `RunShardWithReporter` counts and reports only the skips belonging to that shard's groups.
- `reporter == nil` causes no observable change in execution (pre-existing contract, re-verified).
- Reference `Reporter`'s text output surfaces `Skipped`/`SkippedSpecs`.
- Regression test pinning `Context.Reset` clearing `failFast`.

## Validation

- `gofmt -l` — clean on touched files
- `go build ./...`
- `go vet ./...`
- `go test ./...` — clean, run 3x with `-count=1` to rule out pool-reuse flakiness
- `go test ./specs/... ./report/... -race -count=1`
- `make build`
- `make lint` — 0 issues

## Relationship to #13

Part of #13. This is #13-B: Skipped semantics for Builder/Program/Runner only. Issue #13 stays open — #13-C (Message/Output capture) is still to come.
