### PR TITLE
feat(specs): capture Message/Output for panic recovery and ItParallel failures

### DIFF
--- a/report/events.go
+++ b/report/events.go
@@ -35,7 +35,14 @@ type SpecResultEvent struct {
 	Failed   bool
 	Skipped  bool          // true for a compile-time SkipIt/Skip spec: body never ran, Duration is 0, Failed is always false
 	Duration time.Duration // elapsed time between SpecStartEvent.Time and this event; always 0 when Skipped
-	Message  string
+	Message  string        // short failure summary; empty when not Failed, and also empty for a sequential
+	// Fatalf-based assertion failure — runtime.Goexit unwinds the whole Run call before a SpecFinished
+	// for that spec is ever emitted, so it never reaches this event at all (see specs.runStepRecovered).
+	// Populated today for a recovered panic (the panic value) and for an ItParallel/parallelBackend
+	// failure (the recorded failure string).
+	Output string // full output/stack trace, if any; only a recovered panic produces one today (its
+	// stack trace) — left empty everywhere else, including ItParallel, which has no separable output
+	// source to draw from.
 }
 
 // EventReporter consumes structured events from the spec runner.

--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -3,6 +3,7 @@ package specs
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -260,7 +261,7 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep report
 				// failure occurred.
 				started := reportSpecStarted(rep, name, path)
 				result := runIsolatedCase(backend, program, candidate.Values)
-				reportSpecFinished(rep, started, result.Failed)
+				reportSpecFinished(rep, started, specResult{Failed: result.Failed})
 				return !result.Failed
 			},
 			AdmitFeedback: func(feedback proposalFeedback) {
@@ -276,8 +277,8 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep report
 	ctx.Reset(backend)
 	ctx.SetPathValues(PathValues{})
 	started := reportSpecStarted(rep, name, path)
-	runProgram(program, ctx, nil)
-	reportSpecFinished(rep, started, ctx.failed)
+	message, output := runProgram(program, ctx, nil)
+	reportSpecFinished(rep, started, specResult{Failed: ctx.failed, Message: message, Output: output})
 	return proposalControllerResult{}
 }
 
@@ -311,11 +312,17 @@ func reportSpecStarted(rep report.EventReporter, name string, path []string) rep
 	return e
 }
 
-func reportSpecFinished(rep report.EventReporter, start report.SpecStartEvent, failed bool) {
+func reportSpecFinished(rep report.EventReporter, start report.SpecStartEvent, result specResult) {
 	if rep == nil {
 		return
 	}
-	rep.SpecFinished(report.SpecResultEvent{SpecStartEvent: start, Failed: failed, Duration: time.Since(start.Time)})
+	rep.SpecFinished(report.SpecResultEvent{
+		SpecStartEvent: start,
+		Failed:         result.Failed,
+		Duration:       time.Since(start.Time),
+		Message:        result.Message,
+		Output:         result.Output,
+	})
 }
 
 // runProgram executes one spec's instructions directly in the caller's goroutine (the default,
@@ -323,7 +330,18 @@ func reportSpecFinished(rep report.EventReporter, start report.SpecStartEvent, f
 // A panic anywhere in the before/body instructions is recovered so it fails this one spec instead
 // of crashing the process; after-hook instructions still run regardless, each isolated from the
 // others so one panicking after-hook doesn't stop the rest.
-func runProgram(program []Instruction, ctx *Context, path *PathValues) {
+//
+// On a recovered panic, message and output are built exactly once — message is the short
+// "panic: value" summary, output is the raw stack trace — and reused both for ctx.backend.Errorf
+// (unchanged wire format: "message\noutput") and as the return value runExecutionContext feeds
+// into reportSpecFinished's specResult; they are never reconstructed elsewhere. If the body didn't
+// panic but an after-hook instruction (scoped to this one spec here, unlike the group-shared after
+// hooks in runner.go) did, that after-hook's own message/output (built the same way, once, in
+// runAfterInstructionRecovered) is used instead — first recorded panic wins, matching the
+// first-write-wins convention parallelStep/parallelBackend already use. Both stay "" when the spec
+// didn't panic at all, including when it failed via runtime.Goexit (a real testing.T.Fatalf/FailNow)
+// — recover() cannot observe that case; see specResult's doc comment.
+func runProgram(program []Instruction, ctx *Context, path *PathValues) (message, output string) {
 	if path != nil {
 		ctx.SetPathValues(*path)
 	}
@@ -336,10 +354,15 @@ func runProgram(program []Instruction, ctx *Context, path *PathValues) {
 	defer func() {
 		if recovered := recover(); recovered != nil && !isExpectedAbort(recovered) {
 			ctx.recordFailure()
-			ctx.backend.Errorf("panic: %v\n%s", recovered, debug.Stack())
+			message = fmt.Sprintf("panic: %v", recovered)
+			output = string(debug.Stack())
+			ctx.backend.Errorf("%s\n%s", message, output)
 		}
 		for _, inst := range after {
-			runAfterInstructionRecovered(ctx, inst)
+			m, o := runAfterInstructionRecovered(ctx, inst)
+			if message == "" {
+				message, output = m, o
+			}
 		}
 	}()
 	for _, inst := range program {
@@ -350,18 +373,23 @@ func runProgram(program []Instruction, ctx *Context, path *PathValues) {
 			inst.Fn(ctx)
 		}
 	}
+	return
 }
 
 // runAfterInstructionRecovered runs a single after-hook instruction, recovering any panic so it
-// can't stop the remaining after-hooks for this spec.
-func runAfterInstructionRecovered(ctx *Context, inst Instruction) {
+// can't stop the remaining after-hooks for this spec. message/output follow the same build-once
+// contract as runProgram's own panic recovery — see its doc comment.
+func runAfterInstructionRecovered(ctx *Context, inst Instruction) (message, output string) {
 	defer func() {
 		if recovered := recover(); recovered != nil && !isExpectedAbort(recovered) {
 			ctx.recordFailure()
-			ctx.backend.Errorf("panic in after hook: %v\n%s", recovered, debug.Stack())
+			message = fmt.Sprintf("panic in after hook: %v", recovered)
+			output = string(debug.Stack())
+			ctx.backend.Errorf("%s\n%s", message, output)
 		}
 	}()
 	inst.Fn(ctx)
+	return
 }
 
 // isExpectedAbort reports whether a recovered value is the isolatedCaseAbort sentinel a

--- a/specs/execution_plan_reporter_test.go
+++ b/specs/execution_plan_reporter_test.go
@@ -1,6 +1,7 @@
 package specs
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -213,5 +214,69 @@ func TestDescribeWithoutReporterEmitsNoEvents(t *testing.T) {
 	})
 	if !ran {
 		t.Fatal("expected the spec to still run with a nil reporter")
+	}
+}
+
+// TestRunProgramReportsPanicMessageAndOutput proves a recovered spec-body panic — the one sequential
+// failure path that still reaches reportSpecFinished today, see specResult's doc comment — reports
+// Message as the short "panic: value" summary and Output as the panic's stack trace, built once in
+// runProgram and reused for both the backend's Errorf call and the reported event.
+//
+// This drives runProgram/reportSpecFinished directly (not through DescribeWithReporter) with a
+// controlledBackend, matching TestExecutionPlanRecoversPanicAndContinues's established pattern in
+// execution_plan_recovery_test.go: a real recovered panic calls ctx.backend.Errorf, which — on the
+// real *testing.T a DescribeWithReporter(t, ...) call would use — marks this very test failed too.
+func TestRunProgramReportsPanicMessageAndOutput(t *testing.T) {
+	rep := &recordingReporter{}
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	program := []Instruction{
+		{Code: OpBody, Fn: func(*Context) { panic("boom") }},
+	}
+
+	started := reportSpecStarted(rep, "panics", nil)
+	message, output := runProgram(program, ctx, nil)
+	reportSpecFinished(rep, started, specResult{Failed: ctx.failed, Message: message, Output: output})
+
+	if len(rep.specFinished) != 1 {
+		t.Fatalf("expected one SpecFinished, got %+v", rep.specFinished)
+	}
+	got := rep.specFinished[0]
+	if !got.Failed {
+		t.Fatalf("expected the panicking spec to be reported as failed, got %+v", got)
+	}
+	if got.Message != "panic: boom" {
+		t.Errorf("expected Message %q, got %q", "panic: boom", got.Message)
+	}
+	if !strings.Contains(got.Output, "runProgram") {
+		t.Errorf("expected Output to contain a stack trace naming runProgram, got %q", got.Output)
+	}
+	if len(backend.errors) != 1 || backend.errors[0] != message+"\n"+output {
+		t.Fatalf("expected backend.Errorf to receive exactly message+\"\\n\"+output, got %v", backend.errors)
+	}
+}
+
+// TestRunProgramAfterHookOnlyPanicStillReportsMessage proves that when the spec body itself doesn't
+// panic but its own after-hook does — unlike runner.go's group-shared after hooks, an ExecutionPlan
+// program's after instructions are scoped to this one spec — that after-hook's message/output still
+// feed the spec's result, so Failed=true is never paired with an empty Message.
+func TestRunProgramAfterHookOnlyPanicStillReportsMessage(t *testing.T) {
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend}
+	program := []Instruction{
+		{Code: OpBody, Fn: func(*Context) {}},
+		{Code: OpAfterHook, Fn: func(*Context) { panic("after boom") }},
+	}
+
+	message, output := runProgram(program, ctx, nil)
+
+	if !ctx.failed {
+		t.Fatal("expected ctx.failed to be set after an after-hook panic")
+	}
+	if message != "panic in after hook: after boom" {
+		t.Errorf("expected message %q, got %q", "panic in after hook: after boom", message)
+	}
+	if output == "" {
+		t.Error("expected a non-empty stack trace in output")
 	}
 }

--- a/specs/program.go
+++ b/specs/program.go
@@ -43,6 +43,20 @@ func specName(names []string, i int) string {
 	return names[i]
 }
 
+// specResult is the outcome of one spec's execution, threaded from the two places that can
+// classify it (runSpecsRecovered's runStepRecovered call and parallelStep's per-goroutine recover)
+// through to specExecutionObserver.specFinished. Message/Output are populated only where a real,
+// distinct source exists today — a recovered panic (Message: the panic value, Output: its stack
+// trace) or an ItParallel/parallelBackend failure (Message: the recorded string, Output: left
+// empty — parallelBackend has no separable output source). An ordinary Fatalf-based sequential
+// assertion failure never reaches specFinished at all (runtime.Goexit unwinds the whole Run call
+// before returning here), so Message/Output stay empty for that case too; see runStepRecovered.
+type specResult struct {
+	Failed  bool
+	Message string
+	Output  string
+}
+
 // specExecutionObserver receives per-spec Started/Finished notifications from execution points
 // that only have a *Context to work with, not a *Runner reference — namely a parallelStep
 // goroutine, compiled into the Program before any Runner or Reporter exists. Runner.Run installs
@@ -50,7 +64,7 @@ func specName(names []string, i int) string {
 // execution is unaffected without one.
 type specExecutionObserver interface {
 	specStarted(name string) report.SpecStartEvent
-	specFinished(start report.SpecStartEvent, failed bool)
+	specFinished(start report.SpecStartEvent, result specResult)
 	// specSkipped reports one compile-time-skipped spec (SkipIt/Skip): a single SpecStarted +
 	// SpecFinished{Skipped: true} pair, with no body ever run. Only Runner.Run's sequential group
 	// execution calls this (see runner.go's reportSkipped) — ItParallel/parallelStep has no skip
@@ -148,7 +162,7 @@ func parallelStep(steps []step, names []string) step {
 						}
 					}
 					if obs != nil {
-						obs.specFinished(started, results[i] != "")
+						obs.specFinished(started, specResult{Failed: results[i] != "", Message: results[i]})
 					}
 					child.Reset(nil)
 					contextPool.Put(child)

--- a/specs/runner.go
+++ b/specs/runner.go
@@ -3,6 +3,7 @@
 package specs
 
 import (
+	"fmt"
 	"runtime/debug"
 	"sync"
 	"testing"
@@ -64,14 +65,20 @@ func (o *reporterObserver) specStarted(name string) report.SpecStartEvent {
 	return e
 }
 
-func (o *reporterObserver) specFinished(start report.SpecStartEvent, failed bool) {
+func (o *reporterObserver) specFinished(start report.SpecStartEvent, result specResult) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.total++
-	if failed {
+	if result.Failed {
 		o.failed++
 	}
-	o.rep.SpecFinished(report.SpecResultEvent{SpecStartEvent: start, Failed: failed, Duration: time.Since(start.Time)})
+	o.rep.SpecFinished(report.SpecResultEvent{
+		SpecStartEvent: start,
+		Failed:         result.Failed,
+		Duration:       time.Since(start.Time),
+		Message:        result.Message,
+		Output:         result.Output,
+	})
 }
 
 // specSkipped reports a compile-time-skipped spec: SpecStarted immediately followed by
@@ -240,10 +247,10 @@ func runSpecsRecovered(ctx *Context, g *group) {
 		if named {
 			started = obs.specStarted(g.names[i])
 		}
-		runStepRecovered(ctx, s, "panic")
+		message, output := runStepRecovered(ctx, s, "panic")
 		failed := ctx.failed
 		if named {
-			obs.specFinished(started, failed)
+			obs.specFinished(started, specResult{Failed: failed, Message: message, Output: output})
 		}
 		if ctx.failFast && failed {
 			return
@@ -263,12 +270,22 @@ func runAfterRecovered(ctx *Context, after []step) {
 // runStepRecovered runs a single step, recovering a panic so it fails just this step (recorded via
 // ctx.recordFailure + ctx.backend.Errorf with message and stack trace) instead of crashing the
 // process. label distinguishes a before/spec panic from an after-hook panic in the reported message.
-func runStepRecovered(ctx *Context, s step, label string) {
+//
+// On a recovered panic, message and output are built exactly once here — message is the short
+// "label: value" summary, output is the raw stack trace — and reused both for ctx.backend.Errorf
+// (unchanged wire format: "message\noutput") and as the return value runSpecsRecovered feeds into
+// specFinished's specResult. They are never reconstructed anywhere else. Both are zero-value ("")
+// when s(ctx) returns normally, including via runtime.Goexit (a real testing.T.Fatalf/FailNow) —
+// recover() cannot observe that case, so it is indistinguishable here from a spec that never failed.
+func runStepRecovered(ctx *Context, s step, label string) (message, output string) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			ctx.recordFailure()
-			ctx.backend.Errorf("%s: %v\n%s", label, recovered, debug.Stack())
+			message = fmt.Sprintf("%s: %v", label, recovered)
+			output = string(debug.Stack())
+			ctx.backend.Errorf("%s\n%s", message, output)
 		}
 	}()
 	s(ctx)
+	return
 }

--- a/specs/runner_reporter_test.go
+++ b/specs/runner_reporter_test.go
@@ -2,6 +2,7 @@ package specs
 
 import (
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -214,6 +215,74 @@ func TestParallelStepWithObserverReportsEachSpecIndividually(t *testing.T) {
 	}
 	if obs.total != 3 || obs.failed != 1 {
 		t.Fatalf("expected observer to tally total=3 failed=1, got total=%d failed=%d", obs.total, obs.failed)
+	}
+}
+
+// TestParallelStepWithObserverPassesFailureStringStraightToMessage proves ItParallel's Message
+// comes straight from parallelBackend's already-recorded results[i] string (part of #13-C's scope:
+// ItParallel passes that string through as-is, with no reinterpretation), and that Output stays
+// empty — parallelBackend has no separable output source to draw one from.
+func TestParallelStepWithObserverPassesFailureStringStraightToMessage(t *testing.T) {
+	rep := &recordingReporter{}
+	obs := &reporterObserver{rep: rep}
+	backend := &capturingBackend{}
+	ctx := &Context{backend: backend, execObserver: obs}
+
+	run := parallelStep([]step{
+		runAll([]step{func(*Context) {}}),
+		runAll([]step{func(ctx *Context) { ctx.backend.Errorf("boom: %d", 42) }}),
+	}, []string{"p1", "p2"})
+	run(ctx)
+
+	if len(rep.specFinished) != 2 {
+		t.Fatalf("expected two SpecFinished, got %+v", rep.specFinished)
+	}
+	byName := map[string]report.SpecResultEvent{}
+	for _, e := range rep.specFinished {
+		byName[e.Name] = e
+	}
+	if got := byName["p1"]; got.Failed || got.Message != "" || got.Output != "" {
+		t.Errorf("expected p1 (passing) to have empty Message/Output, got %+v", got)
+	}
+	if got := byName["p2"]; !got.Failed || got.Message != "boom: 42" {
+		t.Errorf("expected p2's Message to be exactly the recorded failure string %q, got %+v", "boom: 42", got)
+	}
+	if got := byName["p2"]; got.Output != "" {
+		t.Errorf("expected p2's Output to stay empty (no separable output source in ItParallel), got %q", got.Output)
+	}
+}
+
+// TestRunSpecsRecoveredReportsPanicMessageAndOutput proves a recovered spec panic (the one sequential
+// failure path that still reaches specFinished today — see specResult's doc comment) reports Message
+// as the short "panic: value" summary and Output as the panic's stack trace, built once and reused
+// for both the backend's Errorf call and the reported event — never reconstructed a second time.
+func TestRunSpecsRecoveredReportsPanicMessageAndOutput(t *testing.T) {
+	rep := &recordingReporter{}
+	obs := &reporterObserver{rep: rep}
+	backend := &controlledBackend{}
+	ctx := &Context{backend: backend, execObserver: obs}
+	g := &group{
+		specs: []step{func(*Context) { panic("boom") }},
+		names: []string{"panics"},
+	}
+
+	runSpecsRecovered(ctx, g)
+
+	if len(rep.specFinished) != 1 {
+		t.Fatalf("expected one SpecFinished, got %+v", rep.specFinished)
+	}
+	got := rep.specFinished[0]
+	if !got.Failed {
+		t.Fatalf("expected the panicking spec to be reported as failed, got %+v", got)
+	}
+	if got.Message != "panic: boom" {
+		t.Errorf("expected Message %q, got %q", "panic: boom", got.Message)
+	}
+	if !strings.Contains(got.Output, "runStepRecovered") {
+		t.Errorf("expected Output to contain a stack trace naming runStepRecovered, got %q", got.Output)
+	}
+	if len(backend.errors) != 1 || backend.errors[0] != got.Message+"\n"+got.Output {
+		t.Fatalf("expected backend.Errorf to receive exactly message+\"\\n\"+output, got %v", backend.errors)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #13. This is the last of the three scoped pieces #13 was split into (#13-A: Duration, PR #72; #13-B: Skipped, PR #73; #13-C: this one, `Message`/`Output`). #13's original ask was to enrich the event schema for structured reporting (JUnit/JSON) — that's now done for every path that reaches the reporter today. The one remaining gap (ordinary sequential assertion failures never reaching the reporter at all, for reasons unrelated to the schema) is documented below and tracked separately in #74, which #13 does not depend on to be considered done.

## Scope decision (read this first)

Before writing code, I traced every place a failure can originate — `Errorf`/`Fatalf` calls, recovered panics, ItParallel results — to find where a structured per-spec result could actually reach the reporter today. The key finding: **every built-in assertion helper in `specs/context.go` only calls `Fatalf`**, never `Error`/`Errorf`. Against the real production backend, `Fatalf` internally calls `runtime.Goexit()`, which unwinds the whole goroutine — and since both execution models run every sequential spec directly in the caller's own goroutine (no per-spec `t.Run` subtest), a real assertion failure terminates the entire `Run`/`Describe` call before that spec's own `SpecFinished`, let alone any later spec, is ever emitted. I verified this empirically with two throwaway probe tests (one per execution model) before deciding anything.

That means an ordinary sequential assertion failure can never produce a `Message`/`Output` today, no matter what this PR does — isolating specs from `Fatalf`/`FailNow` is a real execution-model change (subtest structure, visible test names/timing, tooling/IDE integration), not a reporting change, so I filed it separately: #74. This PR is scoped to the paths that *do* survive to the reporter today:

- **Recovered panics** (spec body panics, and — for `Spec`/`ExecutionPlan` — per-spec after-hook panics).
- **ItParallel/`parallelBackend` failures** (`Fatal`/`Fatalf`/`Error`/`Errorf` inside an `ItParallel` goroutine — these use a `panic(parallelAbort{})` sentinel instead of `testing.T.FailNow`, so they only abort that one goroutine, never the whole suite).

## Design

A small internal `specResult{Failed, Message, Output}` replaces the bare `failed bool` parameter that used to flow into `specFinished` (both `specExecutionObserver.specFinished` in `program.go`/`runner.go`, and `execution_plan.go`'s `reportSpecFinished`). This is the new choke point: it can grow later without another round of parallel parameters, and without turning `Context` or `EventReporter` into an ad hoc collector.

- **Panic recovery** (`runStepRecovered` in `runner.go`; `runProgram`/`runAfterInstructionRecovered` in `execution_plan.go`): `Message`/`Output` are built exactly once, at the existing `Errorf("panic: %v\n%s", ...)` call site — `Message` is the short `"panic: value"` summary, `Output` is the raw stack trace. Both feed the backend's `Errorf` call (same wire format as before: `"message\noutput"`) and the reported event; neither is ever reconstructed a second time.
- **ItParallel** (`parallelStep` in `program.go`): the string already recorded in `results[i]` by `parallelBackend` passes straight through to `Message`, unreinterpreted. `Output` stays empty — `parallelBackend` has no separable output source to draw one from.
- **`Output`**: only populated where a genuinely separate source exists (the panic's stack trace). No artificial Message/Output split anywhere else — same principle #13-B used for `Skipped`: a public field with no real producer is a bad signal.

## What I did *not* touch

- No per-spec `t.Run` isolation — that's #74's scope, not this PR's.
- `runIsolatedCase` (the path-generated/Explore case's existing subtest isolation) is untouched: its `isolatedCaseResult.Panic` field was already unused by any `Errorf` call matching this PR's target pattern, so there was nothing genuine to wire up there without expanding scope.

## Testing

- `TestRunSpecsRecoveredReportsPanicMessageAndOutput` / `TestRunProgramReportsPanicMessageAndOutput` — panic recovery in each execution model; asserts `Message == "panic: boom"`, `Output` contains a real stack frame, and the backend receives exactly `message + "\n" + output`.
- `TestRunProgramAfterHookOnlyPanicStillReportsMessage` — an ExecutionPlan spec whose body passes but whose own after-hook panics still gets a non-empty `Message` (its after hooks are per-spec here, unlike `runner.go`'s group-shared ones).
- `TestParallelStepWithObserverPassesFailureStringStraightToMessage` — ItParallel's `Message` is exactly the recorded failure string, `Output` stays empty, and a passing sibling has both empty.
- Full suite run 3x with `-count=1` (clean), `-race` on `specs`/`report` (clean), `make build`, `make lint` (0 issues).

## Follow-up

Filed #74 for the Fatalf/Goexit sequential-isolation gap — a prerequisite for ever completing `Message`/`Output` on ordinary sequential assertion failures.
