### PR TITLE
fix(specs): isolate sequential spec bodies so Fatalf/FailNow don't kill the whole run

### DIFF
--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -274,12 +274,51 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep report
 		ctx.Reset(nil)
 		contextPool.Put(ctx)
 	}()
-	ctx.Reset(backend)
-	ctx.SetPathValues(PathValues{})
 	started := reportSpecStarted(rep, name, path)
-	message, output := runProgram(program, ctx, nil)
+	message, output := runSpecProgram(backend, ctx, program, name)
 	reportSpecFinished(rep, started, specResult{Failed: ctx.failed, Message: message, Output: output})
 	return proposalControllerResult{}
+}
+
+// runSpecProgram runs program for one ExecutionPlan spec against ctx, isolated in its own subtest
+// when backend wraps a real *testing.T (#74) — same gate runIsolatedCase already uses (see this
+// function's mirror, runSpecRecovered, in runner.go) — so a real Fatalf/FailNow (runtime.Goexit)
+// inside program unwinds only that subtest's goroutine, letting the remaining specs in this plan
+// still run and be reported. A fake backend (e.g. controlledBackend, whose Run is a no-op) or a
+// *testing.B falls back to running program directly against ctx/backend, same as before this
+// isolation existed.
+func runSpecProgram(backend testBackend, ctx *Context, program []Instruction, name string) (message, output string) {
+	real, ok := backend.(*runnableBackend)
+	if !ok {
+		ctx.Reset(backend)
+		ctx.SetPathValues(PathValues{})
+		return runProgram(program, ctx, nil)
+	}
+	t, ok := real.tb.(*testing.T)
+	if !ok {
+		ctx.Reset(backend)
+		ctx.SetPathValues(PathValues{})
+		return runProgram(program, ctx, nil)
+	}
+	return runSpecProgramIsolated(t, ctx, program, name)
+}
+
+// runSpecProgramIsolated creates the real subtest and runs program inside it. Split out from
+// runSpecProgram because the closure below captures named returns by reference: if it lived directly
+// in runSpecProgram, Go's escape analysis would heap-allocate that function's message/output for
+// every call — including the non-*testing.T fast paths above that never reach this line — since
+// escape analysis decides a variable's storage class for the whole function, not per branch. Keeping
+// the capture inside its own function scopes that heap allocation to the isolation path only (see the
+// identical split for runner.go's runSpecRecovered/runSpecIsolated).
+func runSpecProgramIsolated(t *testing.T, ctx *Context, program []Instruction, name string) (message, output string) {
+	t.Run(name, func(subT *testing.T) {
+		subBackend := asTestBackend(subT)
+		defer putTestBackend(subBackend)
+		ctx.Reset(subBackend)
+		ctx.SetPathValues(PathValues{})
+		message, output = runProgram(program, ctx, nil)
+	})
+	return
 }
 
 // specEventName returns plan.Names[i], or "" for a plan built without per-spec metadata (e.g. a

--- a/specs/execution_plan_isolation_test.go
+++ b/specs/execution_plan_isolation_test.go
@@ -1,0 +1,70 @@
+package specs
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestSpecRunRealFatalfIsolatesJustThatSpecRealProcess proves #74's fix end-to-end for the
+// Spec/ExecutionPlan execution model, mirroring TestRunnerRunRealFatalfIsolatesJustThatSpecRealProcess
+// in runner_recovery_test.go for Runner/Program: a real assertion failure (EqualTo, which calls
+// Fatalf under the hood) inside one spec, against a genuine *testing.T, no longer terminates the
+// whole Describe call. Each spec's program now runs in its own subtest when possible (see
+// runSpecProgram in execution_plan.go), so Goexit only unwinds that subtest's goroutine — the
+// remaining specs still run, and every spec, including the failing one, still gets a SpecFinished
+// event. Same subprocess pattern as the Runner test: a nested t.Run's real Fatalf would otherwise
+// mark this outer test failed itself, which would make "did isolation work" indistinguishable from
+// "did this test fail for an unrelated reason."
+func TestSpecRunRealFatalfIsolatesJustThatSpecRealProcess(t *testing.T) {
+	if os.Getenv("GO_SPECS_EXECPLAN_FATALF_ISOLATION_HELPER") == "1" {
+		var rep recordingReporter
+		DescribeWithReporter(t, "suite", &rep, func(s *Spec) {
+			s.It("spec one", func(ctx *Context) { EqualTo(ctx, 1, 2) })
+			s.It("spec two", func(*Context) { fmt.Println("spec2 ran") })
+			s.It("spec three", func(*Context) { fmt.Println("spec3 ran") })
+		})
+		fmt.Printf("suite finished total=%d failed=%d\n", rep.suiteFinished[0].TotalSpecs, rep.suiteFinished[0].FailedSpecs)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSpecRunRealFatalfIsolatesJustThatSpecRealProcess$")
+	cmd.Env = append(os.Environ(), "GO_SPECS_EXECPLAN_FATALF_ISOLATION_HELPER=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the failing spec to fail the process, but it passed: %s", output)
+	}
+	if !strings.Contains(string(output), "spec2 ran") || !strings.Contains(string(output), "spec3 ran") {
+		t.Fatalf("expected specs 2 and 3 to still run after spec 1's real Fatal, got: %s", output)
+	}
+	if !strings.Contains(string(output), "suite finished total=3 failed=1") {
+		t.Fatalf("expected SuiteFinished to report total=3 failed=1 (every spec still reported), got: %s", output)
+	}
+}
+
+// TestSpecRunSpecNamesWithSpacesAndSlashesReportedVerbatim proves a real *testing.T subtest per spec
+// (used for isolation, see runSpecProgram) never leaks into reported spec identity for the
+// Spec/ExecutionPlan execution model, mirroring TestRunnerRunSpecNamesWithSpacesAndSlashesReportedVerbatim
+// for Runner/Program: Go's t.Run sanitizes spaces to "_" and treats "/" as a nested-subtest boundary
+// for -v/-run/test2json presentation, but SpecStartEvent/SpecResultEvent.Name always comes straight
+// from the plan's own Names, so none of that shows up in the reported event. No subprocess needed:
+// neither spec fails.
+func TestSpecRunSpecNamesWithSpacesAndSlashesReportedVerbatim(t *testing.T) {
+	var rep recordingReporter
+	DescribeWithReporter(t, "suite", &rep, func(s *Spec) {
+		s.It("spec with spaces", func(*Context) {})
+		s.It("spec/with/slashes", func(*Context) {})
+	})
+
+	if len(rep.specStarted) != 2 {
+		t.Fatalf("expected 2 SpecStarted events, got %d", len(rep.specStarted))
+	}
+	if got := rep.specStarted[0].Name; got != "spec with spaces" {
+		t.Fatalf("expected reported name %q, got %q", "spec with spaces", got)
+	}
+	if got := rep.specStarted[1].Name; got != "spec/with/slashes" {
+		t.Fatalf("expected reported name %q, got %q", "spec/with/slashes", got)
+	}
+}

--- a/specs/runner.go
+++ b/specs/runner.go
@@ -1,5 +1,6 @@
 // runner.go executes a compiled Program. No hook resolution at runtime; no allocations in the loop
-// unless a Reporter is set.
+// unless a Reporter is set, or the backend is a real *testing.T (each spec body then runs in its own
+// subtest for isolation — see runSpecRecovered).
 package specs
 
 import (
@@ -169,10 +170,12 @@ func runGroups(ctx *Context, groups []group) {
 // Each spec is recovered individually, so one panicking spec doesn't stop its siblings — matching
 // the default execution path's contract (see execution_plan.go's runProgram).
 //
-// after always runs, via defer: whether before or a spec panicked, or a spec called a real
-// t.Fatal/FailNow (runtime.Goexit unwinds through this defer same as a panic would), after gets a
-// chance to clean up whatever before did set up. Each after hook is recovered individually, so one
-// panicking after hook doesn't stop its siblings from attempting to run.
+// after always runs, via defer. A before-hook panic or real t.Fatal/FailNow still unwinds straight
+// through this defer (before is not isolated — see runSpecRecovered's doc comment on why only specs
+// are). A spec's real t.Fatal/FailNow no longer unwinds this goroutine at all (#74): it runs isolated
+// in its own subtest, so runSpecsRecovered's loop returns to this defer normally once the subtest
+// finishes — after still runs either way, just via a different path for each case. Each after hook is
+// recovered individually, so one panicking after hook doesn't stop its siblings from attempting to run.
 //
 // g.skipped is reported first, before before even runs: those names carry no before/after of their
 // own (see builder.go's finalize), so their identity as skipped must not depend on whether this
@@ -238,6 +241,11 @@ func runBeforeRecovered(ctx *Context, before []step) (ok bool) {
 // a parallel group, whose parallelStep closure reports its own real specs instead of one entry per
 // group.specs), SpecStarted/SpecFinished are emitted around the spec using its own captured failed
 // value, not any carry-over from a before hook or a previous spec.
+//
+// Each spec body runs via runSpecRecovered, isolated in its own subtest when possible — see its doc
+// comment (#74). failFast still works correctly across that isolation: t.Run blocks until the
+// subtest's goroutine finishes, so ctx.failed (set synchronously by recordFailure before any Fatalf,
+// not by recover) is visible here exactly like before isolation existed.
 func runSpecsRecovered(ctx *Context, g *group) {
 	obs := ctx.execObserver
 	for i, s := range g.specs {
@@ -247,7 +255,7 @@ func runSpecsRecovered(ctx *Context, g *group) {
 		if named {
 			started = obs.specStarted(g.names[i])
 		}
-		message, output := runStepRecovered(ctx, s, "panic")
+		message, output := runSpecRecovered(ctx, s, specName(g.names, i))
 		failed := ctx.failed
 		if named {
 			obs.specFinished(started, specResult{Failed: failed, Message: message, Output: output})
@@ -256,6 +264,65 @@ func runSpecsRecovered(ctx *Context, g *group) {
 			return
 		}
 	}
+}
+
+// runSpecRecovered runs one spec's body, isolated in its own subtest when ctx.backend is a real
+// *testing.T (via runnableBackend) — so a Fatalf/Fatal/FailNow inside s (runtime.Goexit) unwinds
+// only that subtest's goroutine, not the entire Run/Describe call, letting the remaining specs and
+// this group's after hooks still run and be reported. A fake backend (e.g. controlledBackend in
+// tests, whose Run is a no-op — see runIsolatedCase's identical gate) falls back to running s
+// directly via runStepRecovered, same as before this isolation existed; so does a *testing.B — its
+// concrete type is checked directly here (not via runnableBackend.Run, which would still allocate a
+// closure per call even though it never ends up subtesting) to keep BenchmarkRunner_GoSpecs's
+// existing zero-alloc contract intact.
+//
+// name is the framework's own spec name (group.names[i], via specName — possibly ""), passed to
+// testing.T.Run purely for -v/IDE/test2json presentation. It is never read back from t.Name():
+// SpecStartEvent/SpecResultEvent's Name always comes from group.names, so Go's subtest sanitization
+// (spaces to "_") and duplicate-name "#01" suffixing never leak into reported spec identity.
+func runSpecRecovered(ctx *Context, s step, name string) (message, output string) {
+	real, ok := ctx.backend.(*runnableBackend)
+	if !ok {
+		return runStepRecovered(ctx, s, "panic")
+	}
+	t, ok := real.tb.(*testing.T)
+	if !ok {
+		return runStepRecovered(ctx, s, "panic")
+	}
+	return runSpecIsolated(ctx, t, name, s)
+}
+
+// runSpecIsolated creates the real subtest and runs s inside it. Split out from runSpecRecovered
+// because the closure below captures named returns by reference: if it lived directly in
+// runSpecRecovered, Go's escape analysis would heap-allocate that function's message/output for
+// every call — including the *testing.B fast path above, which never reaches this line at all —
+// since escape analysis decides a variable's storage class for the whole function, not per branch.
+// Keeping the capture inside its own function scopes that heap allocation to the isolation path only.
+func runSpecIsolated(ctx *Context, t *testing.T, name string, s step) (message, output string) {
+	t.Run(name, func(subT *testing.T) {
+		message, output = runSpecBody(ctx, subT, s)
+	})
+	return
+}
+
+// runSpecBody runs s against ctx with ctx.backend/ctx.T temporarily swapped to tb's own backend (tb
+// is this spec's subtest *testing.T, handed in by runSpecRecovered's t.Run) so every assertion helper —
+// all of which read c.backend/e.ctx.backend at call time, never cache it — fails tb, not the parent.
+// That is what makes the Goexit land in this subtest's goroutine instead of the parent's. Restored
+// before returning so the next spec in this group (back in the parent's goroutine) sees the parent's
+// backend/T again, exactly as Context.Reset already does for the analogous runIsolatedCase case.
+func runSpecBody(ctx *Context, tb testing.TB, s step) (message, output string) {
+	subBackend := asTestBackend(tb)
+	defer putTestBackend(subBackend)
+	prevBackend, prevT := ctx.backend, ctx.T
+	ctx.backend = subBackend
+	if t, ok := tb.(*testing.T); ok {
+		ctx.T = t
+	}
+	defer func() {
+		ctx.backend, ctx.T = prevBackend, prevT
+	}()
+	return runStepRecovered(ctx, s, "panic")
 }
 
 // runAfterRecovered runs a group's after hooks in reverse order, recovering each individually.

--- a/specs/runner_recovery_test.go
+++ b/specs/runner_recovery_test.go
@@ -231,3 +231,113 @@ func TestRunnerRunRecoversPanicAcrossGroupsRealProcess(t *testing.T) {
 		t.Fatalf("expected the second group to still run (process must not crash), got: %s", output)
 	}
 }
+
+// TestRunnerRunRealFatalfIsolatesJustThatSpecRealProcess proves #74's fix end-to-end: a real
+// assertion failure (EqualTo, which calls Fatalf under the hood) inside one spec, against a genuine
+// *testing.T (not a fake), no longer terminates the whole Runner.Run call. Spec bodies now each run
+// in their own subtest (see runSpecRecovered), so Goexit only unwinds that subtest's goroutine — the
+// remaining specs in the group still run, and every spec, including the failing one, still gets a
+// SpecFinished event. Same subprocess pattern as TestRunnerRunRecoversPanicAcrossGroupsRealProcess: a
+// nested t.Run's real Fatalf would otherwise mark this outer test failed itself, which would make
+// "did isolation work" indistinguishable from "did this test fail for an unrelated reason."
+func TestRunnerRunRealFatalfIsolatesJustThatSpecRealProcess(t *testing.T) {
+	if os.Getenv("GO_SPECS_RUNNER_FATALF_ISOLATION_HELPER") == "1" {
+		var rep recordingReporter
+		prog := &Program{
+			Groups: []group{
+				{
+					specs: []step{
+						func(ctx *Context) { EqualTo(ctx, 1, 2) },
+						func(*Context) { fmt.Println("spec2 ran") },
+						func(*Context) { fmt.Println("spec3 ran") },
+					},
+					names: []string{"spec one", "spec two", "spec three"},
+				},
+			},
+		}
+		NewRunnerWithReporter(prog, "suite", &rep).Run(t)
+		fmt.Printf("suite finished total=%d failed=%d\n", rep.suiteFinished[0].TotalSpecs, rep.suiteFinished[0].FailedSpecs)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunnerRunRealFatalfIsolatesJustThatSpecRealProcess$")
+	cmd.Env = append(os.Environ(), "GO_SPECS_RUNNER_FATALF_ISOLATION_HELPER=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the failing spec to fail the process, but it passed: %s", output)
+	}
+	if !strings.Contains(string(output), "spec2 ran") || !strings.Contains(string(output), "spec3 ran") {
+		t.Fatalf("expected specs 2 and 3 to still run after spec 1's real Fatal, got: %s", output)
+	}
+	if !strings.Contains(string(output), "suite finished total=3 failed=1") {
+		t.Fatalf("expected SuiteFinished to report total=3 failed=1 (every spec still reported), got: %s", output)
+	}
+}
+
+// TestRunnerRunFailFastStopsAfterRealFatalfRealProcess proves isolation and FailFast compose
+// correctly: EqualTo's recordFailure() sets ctx.failed synchronously before the Fatalf call that
+// triggers Goexit (not learned via recover), and t.Run blocks until the subtest's goroutine
+// finishes — so runSpecsRecovered's failFast check, running right after runSpecRecovered returns,
+// sees the correct value and stops before spec2, exactly as it would have without isolation.
+func TestRunnerRunFailFastStopsAfterRealFatalfRealProcess(t *testing.T) {
+	if os.Getenv("GO_SPECS_RUNNER_FATALF_FAILFAST_HELPER") == "1" {
+		var rep recordingReporter
+		prog := &Program{
+			Groups: []group{
+				{
+					specs: []step{
+						func(ctx *Context) { EqualTo(ctx, 1, 2) },
+						func(*Context) { fmt.Println("spec2 ran") },
+					},
+					names: []string{"spec one", "spec two"},
+				},
+			},
+		}
+		r := NewRunnerWithReporter(prog, "suite", &rep)
+		r.FailFast = true
+		r.Run(t)
+		fmt.Printf("suite finished total=%d failed=%d\n", rep.suiteFinished[0].TotalSpecs, rep.suiteFinished[0].FailedSpecs)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunnerRunFailFastStopsAfterRealFatalfRealProcess$")
+	cmd.Env = append(os.Environ(), "GO_SPECS_RUNNER_FATALF_FAILFAST_HELPER=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the failing spec to fail the process, but it passed: %s", output)
+	}
+	if strings.Contains(string(output), "spec2 ran") {
+		t.Fatalf("expected FailFast to stop spec2 from running after spec1's real Fatal, got: %s", output)
+	}
+	if !strings.Contains(string(output), "suite finished total=1 failed=1") {
+		t.Fatalf("expected SuiteFinished to report total=1 failed=1 (only the failed spec reported before FailFast stopped), got: %s", output)
+	}
+}
+
+// TestRunnerRunSpecNamesWithSpacesAndSlashesReportedVerbatim proves a real *testing.T subtest per
+// spec (used for isolation, see runSpecRecovered) never leaks into reported spec identity: Go's
+// t.Run sanitizes spaces to "_" and treats "/" as a nested-subtest boundary for -v/-run/test2json
+// presentation, but SpecStartEvent/SpecResultEvent.Name always comes straight from group.names, so
+// none of that shows up in the reported event. No subprocess needed — neither spec fails.
+func TestRunnerRunSpecNamesWithSpacesAndSlashesReportedVerbatim(t *testing.T) {
+	var rep recordingReporter
+	prog := &Program{
+		Groups: []group{
+			{
+				specs: []step{func(*Context) {}, func(*Context) {}},
+				names: []string{"spec with spaces", "spec/with/slashes"},
+			},
+		},
+	}
+	NewRunnerWithReporter(prog, "suite", &rep).Run(t)
+
+	if len(rep.specStarted) != 2 {
+		t.Fatalf("expected 2 SpecStarted events, got %d", len(rep.specStarted))
+	}
+	if got := rep.specStarted[0].Name; got != "spec with spaces" {
+		t.Fatalf("expected reported name %q, got %q", "spec with spaces", got)
+	}
+	if got := rep.specStarted[1].Name; got != "spec/with/slashes" {
+		t.Fatalf("expected reported name %q, got %q", "spec/with/slashes", got)
+	}
+}


### PR DESCRIPTION
## Summary

Runner/Program and Spec/ExecutionPlan both used to run every spec body directly in the caller's goroutine. A real `testing.T.Fatalf`/`FailNow` call triggers `runtime.Goexit()`, which unwinds that goroutine entirely — so a genuine assertion failure in one spec silently skipped the rest of the group/suite (remaining specs, `after` hooks, even `SuiteFinished`) instead of failing just that one spec. Design discussion and the implementation contract are in #74.

## What changed

- **`runner.go`** (Runner/Program): `runSpecRecovered` now runs each spec body in its own real `t.Run` subtest when `ctx.backend` wraps a genuine `*testing.T` (gated on the concrete `*runnableBackend`/`*testing.T` types — same precedent `runIsolatedCase` already uses). Fakes (`controlledBackend`, whose `Run` is a no-op) and `*testing.B` fall back to running directly, exactly as before.
- **`execution_plan.go`** (Spec/ExecutionPlan): same isolation, `runSpecProgram`/`runSpecProgramIsolated`, for the non-Paths sequential case. Paths/Explore are untouched — they already isolate per-candidate via `runIsolatedCase`; wrapping again would double-nest subtests.
- Hooks are untouched in both models — only the spec body enters the subtest.
- Reported spec names always come from the framework's own names (`group.names`/`plan.Names`), never `t.Name()` — Go's subtest sanitization (spaces → `_`, `/` as a nesting boundary) never leaks into `SpecStartEvent`/`SpecResultEvent`.
- FailFast (Runner only — ExecutionPlan has no FailFast today) still works correctly: `t.Run` blocks until the subtest's goroutine finishes, so `ctx.failed` (set synchronously by `recordFailure` before the `Fatalf` that triggers Goexit) is visible immediately after, same as before isolation existed.
- Sharding is unaffected — index-based, not name-based.
- No `Message`/`Output` capture added for the newly-isolated failure case, and no `/`-normalization or "safe name" policy — both explicitly out of scope per the design contract in #74; `testing.T.Run`'s standard name semantics apply, covered by a regression test.
- `MinimalRunner`/`BlockRunner`/`BytecodeRunner` are out of scope.

## A note on the implementation vs. the design comment

The design comment on #74 said to reuse `testBackend.Run` directly (`runIsolatedCase`'s exact call shape). While implementing, I found that shape has a real perf cost: a closure that captures a function's own named return values forces Go's escape analysis to heap-allocate those returns for **every** call to the enclosing function — even calls that return before ever reaching the closure literal. That regressed `BenchmarkRunner_GoSpecs` from `0 B/op, 0 allocs/op` to `~80KB/op, 3000 allocs/op`, entirely on the `*testing.B` fast path that never actually subtests.

Fix: split the subtest-creating closure into its own function in both files, and call the concrete `*testing.T.Run` directly instead of going through `testBackend.Run`'s interface indirection. This keeps the isolation contract identical (same gate, same fallback) while restoring zero allocations on the non-`*testing.T` fast path. Confirmed against `BenchmarkRunner_GoSpecs` (Runner) and `BenchmarkHooks_GoSpecs_Nested` (ExecutionPlan, the only existing benchmark that exercises `CompiledSuite.Run`) — both back to baseline.

## Testing

New regression tests, one set per execution model, covering the probes from the #74 investigation:
- Real `Fatalf` (via `EqualTo`) in spec 1 of 3 no longer kills specs 2/3 or `SuiteFinished` (subprocess test — a real Fatal against a nested `t.Run` would otherwise fail the outer test itself).
- FailFast + isolation compose correctly (Runner only): spec 2 doesn't run, `SuiteFinished` reports `total=1 failed=1`.
- Spec names with spaces/slashes are reported verbatim in `SpecStartEvent`/`SpecResultEvent`, despite Go's subtest sanitization.
- Existing `TestGeneratedFatalUsesRealSubtestBoundary` (Paths/Explore) re-verified passing — confirms no double-nested subtests.

Full validation: `go build ./...`, `go vet ./...`, `gofmt -l` (clean on touched files), `go test ./... -count=1`, `go test ./specs/... ./report/... -race -count=1`, `make build`, `make lint` — all clean.

Closes #74.
