### PR TITLE
fix(specs): bound Explore/ExploreCoverage/ExploreSmart attempts under restrictive filters

### DIFF
--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -10,6 +10,13 @@ import (
 const (
 	sampleVarName     = "sample"
 	defaultSampleSeed = int64(1)
+
+	// explorationMaxAttemptsMultiplier bounds total generation attempts (not just accepted
+	// candidates) across Sample, Explore, ExploreCoverage, and ExploreSmart: maxAttempts =
+	// requested budget (samples or iterations) * this multiplier. One shared, named constant
+	// so all four strategies enforce the same "requested budget -> max generation effort"
+	// policy instead of drifting apart with separate magic numbers.
+	explorationMaxAttemptsMultiplier = 100
 )
 
 // ExplorationMode defines how the generator produces values.
@@ -332,11 +339,16 @@ type pathSequence struct {
 	// time. exploreCorpus/exploreSeenSigs are local to this sequence rather than g.corpus/
 	// g.seenSigs — those remain owned by the ForEach/runPlainExploration path so a direct ForEach
 	// call and an incremental sequence() walk never share (and corrupt) the same corpus. The
-	// filter-retry loop is internal to nextExplore, same as nextSample.
-	exploreSeeded   bool
-	exploreExecuted int
-	exploreCorpus   []PathValues
-	exploreSeenSigs map[uint64]struct{}
+	// filter-retry loop is internal to nextExplore, same as nextSample. exploreAttempts/
+	// exploreMaxAttempts cap that internal retry loop the same way sampleAttempts/
+	// sampleMaxAttempts cap nextSample's — a restrictive-to-impossible filter must fail loudly
+	// instead of spinning forever (#18).
+	exploreSeeded      bool
+	exploreExecuted    int
+	exploreAttempts    int
+	exploreMaxAttempts int
+	exploreCorpus      []PathValues
+	exploreSeenSigs    map[uint64]struct{}
 
 	// ExploreCoverage/ExploreSmart: mirrors runGuidedExploration's state one call to next() at a
 	// time. Unlike exploreSeenSigs above, guidedSeenSigs is the only local copy needed — NextInput
@@ -346,8 +358,11 @@ type pathSequence struct {
 	// copy; there is no g.corpus-equivalent field to avoid contaminating for these two strategies.
 	// guidedSeenSigs stays local so a direct ForEach call and an incremental sequence() walk never
 	// share (and corrupt) the same signature set — same discipline as exploreSeenSigs vs g.seenSigs.
-	guidedExecuted int
-	guidedSeenSigs map[uint64]struct{}
+	// guidedAttempts/guidedMaxAttempts cap the internal retry loop, same reasoning as Explore (#18).
+	guidedExecuted    int
+	guidedAttempts    int
+	guidedMaxAttempts int
+	guidedSeenSigs    map[uint64]struct{}
 }
 
 // sequence returns a pathSequence for g, incremental for every ExplorationMode (Cartesian,
@@ -369,7 +384,7 @@ func (g *PathGenerator) sequence() *pathSequence {
 		return seq
 	case SamplingMode:
 		seq.sampleIdx, seq.hasSampleVar = g.index[sampleVarName]
-		seq.sampleMaxAttempts = g.samples * 100
+		seq.sampleMaxAttempts = g.samples * explorationMaxAttemptsMultiplier
 		if seq.sampleMaxAttempts < g.samples {
 			seq.sampleMaxAttempts = g.samples
 		}
@@ -378,12 +393,18 @@ func (g *PathGenerator) sequence() *pathSequence {
 		}
 		return seq
 	case ExplorationGuided:
+		maxAttempts := g.iterations * explorationMaxAttemptsMultiplier
+		if maxAttempts < g.iterations {
+			maxAttempts = g.iterations
+		}
 		switch g.strategy {
 		case strategyPlain:
 			seq.exploreCorpus = make([]PathValues, 0, g.iterations/10+1)
 			seq.exploreSeenSigs = make(map[uint64]struct{})
+			seq.exploreMaxAttempts = maxAttempts
 		case strategyCoverage, strategySmart:
 			seq.guidedSeenSigs = make(map[uint64]struct{})
+			seq.guidedMaxAttempts = maxAttempts
 		}
 		if g.iterations <= 0 {
 			seq.done = true
@@ -467,6 +488,12 @@ func (s *pathSequence) nextSample() (PathValues, bool) {
 // candidate plus the first accepted candidate from this loop. That's an existing, documented
 // heuristic limitation (see runGuidedExploration's doc comment), not something introduced here;
 // this method preserves it exactly rather than changing observable behavior.
+//
+// The filter-retry loop is capped by exploreAttempts/exploreMaxAttempts, same shape as
+// nextSample: a restrictive-to-impossible filter panics with a diagnostic message instead of
+// spinning forever (#18) — total attempts across the whole Explore run, not consecutive
+// rejections, since a filter that admits occasionally could reset a consecutive counter
+// indefinitely without ever tripping it.
 func (s *pathSequence) nextExplore() (PathValues, bool) {
 	g := s.g
 	if !s.exploreSeeded {
@@ -486,6 +513,13 @@ func (s *pathSequence) nextExplore() (PathValues, bool) {
 		return PathValues{}, false
 	}
 	for {
+		s.exploreAttempts++
+		if s.exploreAttempts > s.exploreMaxAttempts {
+			panic(fmt.Sprintf(
+				"specs: Explore could not satisfy filters after %d attempts (%d/%d iterations accepted); relax filters or reduce iterations",
+				s.exploreAttempts-1, s.exploreExecuted, g.iterations,
+			))
+		}
 		var candidate PathValues
 		if len(s.exploreCorpus) > 0 && g.rng.Float64() > 0.3 {
 			candidate = g.mutate(s.exploreCorpus[g.rng.Intn(len(s.exploreCorpus))])
@@ -512,6 +546,10 @@ func (s *pathSequence) nextExplore() (PathValues, bool) {
 // the proxy, not real per-iteration coverage, still drives corpus growth here. Unlike nextExplore,
 // there is no separate seed step: runGuidedExploration doesn't have one either, so growth caps at
 // exactly one corpus entry (the first accepted candidate) rather than two.
+//
+// The filter-retry loop is capped by guidedAttempts/guidedMaxAttempts, same reasoning as
+// nextExplore (#18): total attempts across the run, not consecutive rejections, and a diagnostic
+// panic instead of spinning forever.
 func (s *pathSequence) nextGuided() (PathValues, bool) {
 	g := s.g
 	if s.guidedExecuted >= g.iterations {
@@ -520,6 +558,7 @@ func (s *pathSequence) nextGuided() (PathValues, bool) {
 	}
 	var nextInput func(*PathGenerator) PathValues
 	var corpus *Corpus
+	strategyName := "ExploreCoverage"
 	switch g.strategy {
 	case strategyCoverage:
 		nextInput = g.coverageExplorer.NextInput
@@ -527,8 +566,16 @@ func (s *pathSequence) nextGuided() (PathValues, bool) {
 	case strategySmart:
 		nextInput = g.smartExplorer.NextInput
 		corpus = g.smartExplorer.corpus
+		strategyName = "ExploreSmart"
 	}
 	for {
+		s.guidedAttempts++
+		if s.guidedAttempts > s.guidedMaxAttempts {
+			panic(fmt.Sprintf(
+				"specs: %s could not satisfy filters after %d attempts (%d/%d iterations accepted); relax filters or reduce iterations",
+				strategyName, s.guidedAttempts-1, s.guidedExecuted, g.iterations,
+			))
+		}
 		candidate := nextInput(g)
 		if !g.allow(candidate) {
 			continue

--- a/specs/path_generator_test.go
+++ b/specs/path_generator_test.go
@@ -2,6 +2,7 @@ package specs
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -464,11 +465,64 @@ func TestPathSequenceSmartAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
 	}
 }
 
+// TestPathSequenceExplorePanicsWhenFiltersCannotBeSatisfied is #18's regression: before the
+// attempt budget, an impossible filter made nextExplore's internal retry loop spin forever
+// instead of failing. Same shape as TestPathSequenceSamplePanicsWhenFiltersCannotBeSatisfied.
+func TestPathSequenceExplorePanicsWhenFiltersCannotBeSatisfied(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", Values: []any{1}},
+	}, []PathFilter{func(PathValues) bool { return false }}, 0, 0, false, 3, 0, 0)
+
+	seq := gen.sequence()
+	assertPanicsWith(t, func() { seq.next() }, "Explore", "attempts", "iterations")
+}
+
+func TestPathSequenceCoveragePanicsWhenFiltersCannotBeSatisfied(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", Values: []any{1}},
+	}, []PathFilter{func(PathValues) bool { return false }}, 0, 0, false, 0, 3, 0)
+
+	seq := gen.sequence()
+	assertPanicsWith(t, func() { seq.next() }, "ExploreCoverage", "attempts", "iterations")
+}
+
+func TestPathSequenceSmartPanicsWhenFiltersCannotBeSatisfied(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", Values: []any{1}},
+	}, []PathFilter{func(PathValues) bool { return false }}, 0, 0, false, 0, 0, 3)
+
+	seq := gen.sequence()
+	assertPanicsWith(t, func() { seq.next() }, "ExploreSmart", "attempts", "iterations")
+}
+
 func assertPanics(t *testing.T, fn func()) {
 	t.Helper()
 	defer func() {
 		if recover() == nil {
 			t.Fatal("expected a panic")
+		}
+	}()
+	fn()
+}
+
+// assertPanicsWith is assertPanics plus a check that the panic message names the diagnostics
+// #18 requires: which strategy hit the budget, and that it's about attempts/iterations, not a
+// bare failure with no actionable detail.
+func assertPanicsWith(t *testing.T, fn func(), wantSubstrings ...string) {
+	t.Helper()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected a panic")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected a string panic message, got %T: %v", r, r)
+		}
+		for _, want := range wantSubstrings {
+			if !strings.Contains(msg, want) {
+				t.Fatalf("panic message %q missing expected substring %q", msg, want)
+			}
 		}
 	}()
 	fn()

--- a/specs/paths_test.go
+++ b/specs/paths_test.go
@@ -493,6 +493,77 @@ func TestExploreSmartRuns(t *testing.T) {
 	})
 }
 
+// The following tests exercise the real execution path (Describe/Paths().Explore*()) rather than
+// pathSequence directly, so the attempt-budget fix (#18) is proven against what actually runs in
+// production, not just against the generator in isolation.
+
+func TestPathsExploreImpossibleFilterPanicsWithDiagnostics(t *testing.T) {
+	assertPanicsWith(t, func() {
+		Describe(t, "PathsExploreImpossibleFilter", func(s *Spec) {
+			s.Paths(func(pb *PathBuilder) {
+				pb.IntRange("x", 0, 100)
+				pb.Filter(func(PathValues) bool { return false })
+			}).Explore(5).It("never runs", func(ctx *Context) {
+				t.Fatal("case must not execute when the filter admits nothing")
+			})
+		})
+	}, "Explore", "attempts", "iterations")
+}
+
+func TestPathsExploreCoverageImpossibleFilterPanicsWithDiagnostics(t *testing.T) {
+	assertPanicsWith(t, func() {
+		Describe(t, "PathsExploreCoverageImpossibleFilter", func(s *Spec) {
+			s.Paths(func(pb *PathBuilder) {
+				pb.IntRange("x", 0, 100)
+				pb.Filter(func(PathValues) bool { return false })
+			}).ExploreCoverage(5).It("never runs", func(ctx *Context) {
+				t.Fatal("case must not execute when the filter admits nothing")
+			})
+		})
+	}, "ExploreCoverage", "attempts", "iterations")
+}
+
+func TestPathsExploreSmartImpossibleFilterPanicsWithDiagnostics(t *testing.T) {
+	assertPanicsWith(t, func() {
+		Describe(t, "PathsExploreSmartImpossibleFilter", func(s *Spec) {
+			s.Paths(func(pb *PathBuilder) {
+				pb.IntRange("x", 0, 100)
+				pb.Filter(func(PathValues) bool { return false })
+			}).ExploreSmart(5).It("never runs", func(ctx *Context) {
+				t.Fatal("case must not execute when the filter admits nothing")
+			})
+		})
+	}, "ExploreSmart", "attempts", "iterations")
+}
+
+// TestPathsExploreRestrictiveFilterStillReachesIterations guards against the new attempt budget
+// tripping on a filter that is restrictive but satisfiable — it must still reach exactly
+// `iterations`, not fail early just because acceptance is rare.
+func TestPathsExploreRestrictiveFilterStillReachesIterations(t *testing.T) {
+	const iterations = 20
+	var mu sync.Mutex
+	var count int
+	Describe(t, "PathsExploreRestrictiveFilter", func(s *Spec) {
+		s.Paths(func(pb *PathBuilder) {
+			pb.IntRange("x", 0, 100)
+			pb.Filter(func(v PathValues) bool {
+				return v.Int("x")%10 == 0
+			})
+		}).Explore(iterations).It("multiple of ten", func(ctx *Context) {
+			x := ctx.Path().Int("x")
+			if x%10 != 0 {
+				ctx.T.Fatalf("expected multiple of ten, got %d", x)
+			}
+			mu.Lock()
+			count++
+			mu.Unlock()
+		})
+	})
+	if count != iterations {
+		t.Fatalf("expected %d iterations under a restrictive-but-viable filter, got %d", iterations, count)
+	}
+}
+
 func TestShrinkerCoordinateDescentMultipleInts(t *testing.T) {
 	gen := newPathGenerator([]PathVar{
 		{Name: "x", rangeSpec: &intRange{min: 0, max: 1000}},


### PR DESCRIPTION
## Summary

`pathSequence.nextExplore`/`nextGuided` — the methods the incremental execution path (`runExecutionContext` → `pathSequence.sequence()`/`next()`) dispatches to for `ExplorationGuided` mode — had an unbounded filter-retry loop. An impossible or very restrictive `PathFilter` under `Explore`/`ExploreCoverage`/`ExploreSmart` could spin `pathSequence.next()` forever, since the retries happen *inside* a single `next()` call and never surface as separate `Propose()` calls to `proposalController` (`bounds()` returns exactly `iterations` for these modes, so the controller-level `MaxAttempts` can't catch it).

Closes #18.

## Design (see #18 for the full discussion/correction)

- **Total attempts budget, not consecutive rejections** — a filter that admits occasionally could reset a consecutive-rejection counter indefinitely without ever tripping it.
- **Mirrors `nextSample`'s existing precedent exactly**: a per-sequence attempt counter, `maxAttempts = iterations * explorationMaxAttemptsMultiplier` (new shared, named constant = 100, replacing the previously-inline `* 100` in `nextSample` too — one policy for all four strategies instead of separate magic numbers), and a diagnostic `panic` on exhaustion naming strategy, accepted/executed count, attempts, and the iteration limit — not a silent reduction in produced candidates.
- **No public API changes, no new `context.Context`.** `proposalController` untouched — its limits/cancellation are correct for the execution phase, but arrive too late to prevent the block inside a single `next()` call. `CartesianMode`/`nextFiltered` out of scope (already has finite exhaustion).
- **`ForEach`/`runPlainExploration`/`runGuidedExploration` are deliberately out of scope for this PR.** They're dead code for the production execution path today (`runExecutionContext` calls `gen.sequence()` unconditionally; `ForEach`'s own doc comment confirms this — only reachable via a direct/standalone `PathGenerator.ForEach()` call, e.g. `explore_mode_selection_test.go`). Touching them would mix fixing a real runtime hang with hardening an unrelated standalone/compat API, without adding coverage for the reported bug. Worth a separate future issue if it should be hardened too.
- Propagating `context.Context` through this path, or converting Explore/Coverage/Smart fully to the incremental model's cancellation semantics, is a separate future architectural follow-up — not part of this fix.

## Changes

- `specs/path_generator.go`: `explorationMaxAttemptsMultiplier` shared constant; `exploreAttempts`/`exploreMaxAttempts` and `guidedAttempts`/`guidedMaxAttempts` fields on `pathSequence`; budget computed in `sequence()`; attempt counting + diagnostic panic added to `nextExplore`/`nextGuided`'s retry loops.
- `specs/path_generator_test.go`: unit-level panic/diagnostic tests for Explore/Coverage/Smart at the `pathSequence` level, plus a shared `assertPanicsWith` helper (asserts the panic message names the strategy and mentions attempts/iterations).
- `specs/paths_test.go`: **execution-path-level tests** via `Describe`/`Paths().Explore*()` (not just direct `pathSequence` calls) — impossible-filter panic tests for Explore/Coverage/Smart, plus a restrictive-but-viable regression proving `iterations` is still reached exactly.

## Test plan

- [x] `go build ./...`
- [x] Targeted: `go test ./specs/... -run 'TestPathsExplore|TestPathSequence.*PanicsWhenFiltersCannotBeSatisfied' -v` — all pass, including the execution-path panic tests
- [x] `go vet ./...` — clean
- [x] `go test ./... -race` — all 20 packages `ok`, no failures
- [x] `golangci-lint run ./...` — 1 pre-existing issue in `tools/perfcheck/main.go` (errcheck on `f.Close()`), outside this diff; nothing new introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)