### PR TITLE
fix(specs): move guided-exploration corpus growth to post-execution admitFeedback

### DIFF
--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -479,15 +479,13 @@ func (s *pathSequence) nextSample() (PathValues, bool) {
 	}
 }
 
-// nextExplore mirrors runPlainExploration: seed the corpus with one random candidate (if it
-// passes filters), then on each call either mutate a random corpus entry (70% of the time, once
-// the corpus is non-empty) or draw a fully random candidate, retrying internally against filters.
-// captureSignature() is called from this fixed call site for every candidate in the sequence, so
-// — same as runPlainExploration calling it from its own fixed loop line — it yields the same
-// signature every time within one sequence, meaning exploreCorpus only ever grows by the seed
-// candidate plus the first accepted candidate from this loop. That's an existing, documented
-// heuristic limitation (see runGuidedExploration's doc comment), not something introduced here;
-// this method preserves it exactly rather than changing observable behavior.
+// nextExplore mirrors runPlainExploration's candidate proposal: seed the corpus with one random
+// candidate (if it passes filters), then on each call either mutate a random corpus entry (70% of
+// the time, once the corpus is non-empty) or draw a fully random candidate, retrying internally
+// against filters. Corpus growth from the proposed candidate itself no longer happens here — the
+// proposalController only knows a candidate is real once it has actually run, so growth is
+// admitted by admitFeedback after execution (see that method's doc comment). The seed step above
+// is not itself a proposed/executed candidate, so it stays here, unconditional, exactly as before.
 //
 // The filter-retry loop is capped by exploreAttempts/exploreMaxAttempts, same shape as
 // nextSample: a restrictive-to-impossible filter panics with a diagnostic message instead of
@@ -530,22 +528,13 @@ func (s *pathSequence) nextExplore() (PathValues, bool) {
 			continue
 		}
 		s.exploreExecuted++
-		sig := captureSignature()
-		if _, seen := s.exploreSeenSigs[sig]; !seen {
-			s.exploreSeenSigs[sig] = struct{}{}
-			s.exploreCorpus = append(s.exploreCorpus, candidate.clone())
-		}
 		return candidate, true
 	}
 }
 
-// nextGuided mirrors runGuidedExploration exactly for strategyCoverage/strategySmart: draw a
-// candidate from the CoverageExplorer's/SmartExplorer's own NextInput, retry internally against
-// filters, and on acceptance grow that explorer's own corpus via the same captureSignature()
-// call-site novelty proxy runGuidedExploration already uses — see that method's doc comment for why
-// the proxy, not real per-iteration coverage, still drives corpus growth here. Unlike nextExplore,
-// there is no separate seed step: runGuidedExploration doesn't have one either, so growth caps at
-// exactly one corpus entry (the first accepted candidate) rather than two.
+// nextGuided mirrors runGuidedExploration's candidate proposal for strategyCoverage/
+// strategySmart: draw a candidate from the CoverageExplorer's/SmartExplorer's own NextInput,
+// retrying internally against filters. Corpus growth no longer happens here — see admitFeedback.
 //
 // The filter-retry loop is capped by guidedAttempts/guidedMaxAttempts, same reasoning as
 // nextExplore (#18): total attempts across the run, not consecutive rejections, and a diagnostic
@@ -557,15 +546,12 @@ func (s *pathSequence) nextGuided() (PathValues, bool) {
 		return PathValues{}, false
 	}
 	var nextInput func(*PathGenerator) PathValues
-	var corpus *Corpus
 	strategyName := "ExploreCoverage"
 	switch g.strategy {
 	case strategyCoverage:
 		nextInput = g.coverageExplorer.NextInput
-		corpus = g.coverageExplorer.corpus
 	case strategySmart:
 		nextInput = g.smartExplorer.NextInput
-		corpus = g.smartExplorer.corpus
 		strategyName = "ExploreSmart"
 	}
 	for {
@@ -581,11 +567,6 @@ func (s *pathSequence) nextGuided() (PathValues, bool) {
 			continue
 		}
 		s.guidedExecuted++
-		sig := captureSignature()
-		if _, seen := s.guidedSeenSigs[sig]; !seen {
-			s.guidedSeenSigs[sig] = struct{}{}
-			corpus.Add(candidate)
-		}
 		return candidate, true
 	}
 }
@@ -639,16 +620,46 @@ func (s *pathSequence) advance() bool {
 	return false
 }
 
-// admitFeedback reports the real outcome of executing candidate back to the generator. It is a
-// no-op for all five supported mode/strategy combinations: none has feedback-dependent state today.
-// Sample's candidates are drawn independently of prior results, same as runSamples always was.
-// Explore/ExploreCoverage/ExploreSmart's corpus growth is driven by captureSignature()'s call-site
-// novelty proxy inside nextExplore/nextGuided, not by whether the candidate passed — so
-// admitFeedback has nothing to do for any of them, even though it now runs after the real case (see
-// nextExplore's/nextGuided's doc comments). Genuinely reacting to passed for ExploreCoverage/
-// ExploreSmart would require wiring real per-iteration coverage into Feedback (see
-// runGuidedExploration's doc comment) — deliberately out of scope for this migration; see #43.
-func (s *pathSequence) admitFeedback(candidate PathValues, passed bool) {}
+// admitFeedback reports the real outcome of executing candidate back to the generator. It is the
+// only place Explore/ExploreCoverage/ExploreSmart grow their corpus: nextExplore/nextGuided only
+// propose a candidate, they never know whether it will actually run (the proposalController may
+// still reject it), so corpus growth belongs here, after runIsolatedCase has genuinely executed
+// it. Cartesian and Sample stay no-ops: neither has feedback-dependent state.
+//
+// Growth is still driven by captureSignature()'s call-site novelty proxy, not by passed — that
+// part of the heuristic is unchanged, only moved to run after execution instead of before it.
+// captureSignature() is called from this one fixed call site for every admitted candidate across
+// the whole sequence, so — same as it always was when called from nextExplore/nextGuided — it
+// yields the same signature every time within one sequence: exploreCorpus grows by the seed
+// candidate plus the first admitted candidate, and the guided corpus grows by exactly the first
+// admitted candidate. That's the existing, documented heuristic limitation (see nextGuided's doc
+// comment and #54), not something introduced here.
+//
+// Wiring passed (or real per-iteration coverage) into corpus growth is exactly what #54 tracks as
+// the next step, now that growth has a real post-execution hook to react from.
+func (s *pathSequence) admitFeedback(candidate PathValues, passed bool) {
+	if s == nil || s.g == nil || s.g.mode != ExplorationGuided {
+		return
+	}
+	switch s.g.strategy {
+	case strategyPlain:
+		sig := captureSignature()
+		if _, seen := s.exploreSeenSigs[sig]; !seen {
+			s.exploreSeenSigs[sig] = struct{}{}
+			s.exploreCorpus = append(s.exploreCorpus, candidate.clone())
+		}
+	case strategyCoverage, strategySmart:
+		sig := captureSignature()
+		if _, seen := s.guidedSeenSigs[sig]; !seen {
+			s.guidedSeenSigs[sig] = struct{}{}
+			if s.g.strategy == strategyCoverage {
+				s.g.coverageExplorer.corpus.Add(candidate)
+			} else {
+				s.g.smartExplorer.corpus.Add(candidate)
+			}
+		}
+	}
+}
 
 // bounds returns conservative (never-underestimating) MaxAttempts/MaxAccepted/MaxRejections
 // upper bounds for proposalControllerConfig, computed without generating a single candidate, for

--- a/specs/path_generator_test.go
+++ b/specs/path_generator_test.go
@@ -27,6 +27,25 @@ func collectForEach(g *PathGenerator) []string {
 	return want
 }
 
+// collectSequenceWithFeedback drains a pathSequence like collectSequence, but — matching how
+// runExecutionContext actually drives a sequence in production — calls admitFeedback(pv, true)
+// right after each next(), before proposing the next candidate. For Explore/Coverage/Smart this
+// interleaving is what makes their incremental corpus growth line up with ForEach's synchronous
+// growth timing; plain collectSequence (no feedback) leaves their corpus frozen at the seed.
+func collectSequenceWithFeedback(g *PathGenerator) []string {
+	seq := g.sequence()
+	var got []string
+	for {
+		pv, ok := seq.next()
+		if !ok {
+			break
+		}
+		got = append(got, g.FormatPathValuesForReport(pv))
+		seq.admitFeedback(pv, true)
+	}
+	return got
+}
+
 func TestPathSequenceCartesianMatchesForEachOrder(t *testing.T) {
 	gen := newPathGenerator([]PathVar{
 		{Name: "x", Values: []any{1, 2, 3}},
@@ -220,7 +239,10 @@ func TestPathSequenceExploreMatchesForEachForSameSeed(t *testing.T) {
 		}, nil, 0, 42, true, 6, 0, 0)
 	}
 
-	got := collectSequence(newGen())
+	// Corpus growth now happens in admitFeedback, not next() — so the comparison must drive the
+	// sequence the way runExecutionContext actually does (next() then admitFeedback()) to match
+	// ForEach's synchronous growth timing. See collectSequenceWithFeedback's doc comment.
+	got := collectSequenceWithFeedback(newGen())
 	want := collectForEach(newGen())
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sequence-based explore = %v, want %v (must match runPlainExploration exactly for the same seed)", got, want)
@@ -264,28 +286,36 @@ func TestPathSequenceExploreBoundsIsExact(t *testing.T) {
 	}
 }
 
-func TestPathSequenceExploreAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
-	newGen := func() *PathGenerator {
-		return newPathGenerator([]PathVar{
-			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
-		}, nil, 0, 7, true, 6, 0, 0)
-	}
+// TestPathSequenceExploreCorpusGrowsOnlyAfterAdmitFeedback is #54's PR A architectural boundary:
+// nextExplore only proposes candidates, it must never grow exploreCorpus itself — corpus growth
+// happens exclusively in admitFeedback, after the candidate has actually run. This freezes the
+// post-execution feedback boundary that PR B (real coverage) will build on.
+func TestPathSequenceExploreCorpusGrowsOnlyAfterAdmitFeedback(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+	}, nil, 0, 7, true, 6, 0, 0)
 
-	baseline := collectSequence(newGen())
-
-	gen := newGen()
 	seq := gen.sequence()
-	var withFeedback []string
-	for {
-		pv, ok := seq.next()
-		if !ok {
-			break
-		}
-		withFeedback = append(withFeedback, gen.FormatPathValuesForReport(pv))
-		seq.admitFeedback(pv, withFeedback != nil)
+	pv, ok := seq.next()
+	if !ok {
+		t.Fatal("expected a candidate")
 	}
-	if !reflect.DeepEqual(baseline, withFeedback) {
-		t.Fatalf("admitFeedback altered the sequence: got %v, want %v", withFeedback, baseline)
+	if got := len(seq.exploreCorpus); got != 1 {
+		t.Fatalf("next() grew the corpus: len(exploreCorpus) = %d, want 1 (seed only, before any admitFeedback)", got)
+	}
+
+	seq.admitFeedback(pv, true)
+	if got := len(seq.exploreCorpus); got != 2 {
+		t.Fatalf("admitFeedback did not grow the corpus: len(exploreCorpus) = %d, want 2 (seed + admitted candidate)", got)
+	}
+
+	// Further next() calls must not grow the corpus either — only admitFeedback does.
+	before := len(seq.exploreCorpus)
+	if _, ok := seq.next(); !ok {
+		t.Fatal("expected a second candidate")
+	}
+	if got := len(seq.exploreCorpus); got != before {
+		t.Fatalf("a later next() grew the corpus: len(exploreCorpus) = %d, want %d (unchanged)", got, before)
 	}
 }
 
@@ -308,7 +338,9 @@ func TestPathSequenceCoverageMatchesForEachForSameSeed(t *testing.T) {
 		}, nil, 0, 42, true, 0, 6, 0)
 	}
 
-	got := collectSequence(newGen())
+	// See TestPathSequenceExploreMatchesForEachForSameSeed: growth moved to admitFeedback, so the
+	// comparison must interleave it the way production dispatch does.
+	got := collectSequenceWithFeedback(newGen())
 	want := collectForEach(newGen())
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sequence-based ExploreCoverage = %v, want %v (must match runGuidedExploration exactly for the same seed)", got, want)
@@ -352,28 +384,33 @@ func TestPathSequenceCoverageBoundsIsExact(t *testing.T) {
 	}
 }
 
-func TestPathSequenceCoverageAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
-	newGen := func() *PathGenerator {
-		return newPathGenerator([]PathVar{
-			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
-		}, nil, 0, 7, true, 0, 6, 0)
-	}
+// TestPathSequenceCoverageCorpusGrowsOnlyAfterAdmitFeedback mirrors the Explore case: nextGuided
+// must not grow the CoverageExplorer's corpus itself; only admitFeedback does, after execution.
+func TestPathSequenceCoverageCorpusGrowsOnlyAfterAdmitFeedback(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+	}, nil, 0, 7, true, 0, 6, 0)
 
-	baseline := collectSequence(newGen())
-
-	gen := newGen()
 	seq := gen.sequence()
-	var withFeedback []string
-	for {
-		pv, ok := seq.next()
-		if !ok {
-			break
-		}
-		withFeedback = append(withFeedback, gen.FormatPathValuesForReport(pv))
-		seq.admitFeedback(pv, withFeedback != nil)
+	pv, ok := seq.next()
+	if !ok {
+		t.Fatal("expected a candidate")
 	}
-	if !reflect.DeepEqual(baseline, withFeedback) {
-		t.Fatalf("admitFeedback altered the sequence: got %v, want %v", withFeedback, baseline)
+	if got := gen.coverageExplorer.CorpusLen(); got != 0 {
+		t.Fatalf("next() grew the corpus: CorpusLen() = %d, want 0 (before any admitFeedback)", got)
+	}
+
+	seq.admitFeedback(pv, true)
+	if got := gen.coverageExplorer.CorpusLen(); got != 1 {
+		t.Fatalf("admitFeedback did not grow the corpus: CorpusLen() = %d, want 1", got)
+	}
+
+	before := gen.coverageExplorer.CorpusLen()
+	if _, ok := seq.next(); !ok {
+		t.Fatal("expected a second candidate")
+	}
+	if got := gen.coverageExplorer.CorpusLen(); got != before {
+		t.Fatalf("a later next() grew the corpus: CorpusLen() = %d, want %d (unchanged)", got, before)
 	}
 }
 
@@ -396,7 +433,9 @@ func TestPathSequenceSmartMatchesForEachForSameSeed(t *testing.T) {
 		}, nil, 0, 42, true, 0, 0, 6)
 	}
 
-	got := collectSequence(newGen())
+	// See TestPathSequenceExploreMatchesForEachForSameSeed: growth moved to admitFeedback, so the
+	// comparison must interleave it the way production dispatch does.
+	got := collectSequenceWithFeedback(newGen())
 	want := collectForEach(newGen())
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sequence-based ExploreSmart = %v, want %v (must match runGuidedExploration exactly for the same seed)", got, want)
@@ -440,28 +479,33 @@ func TestPathSequenceSmartBoundsIsExact(t *testing.T) {
 	}
 }
 
-func TestPathSequenceSmartAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
-	newGen := func() *PathGenerator {
-		return newPathGenerator([]PathVar{
-			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
-		}, nil, 0, 7, true, 0, 0, 6)
-	}
+// TestPathSequenceSmartCorpusGrowsOnlyAfterAdmitFeedback mirrors the Explore/Coverage cases:
+// nextGuided must not grow the SmartExplorer's corpus itself; only admitFeedback does.
+func TestPathSequenceSmartCorpusGrowsOnlyAfterAdmitFeedback(t *testing.T) {
+	gen := newPathGenerator([]PathVar{
+		{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
+	}, nil, 0, 7, true, 0, 0, 6)
 
-	baseline := collectSequence(newGen())
-
-	gen := newGen()
 	seq := gen.sequence()
-	var withFeedback []string
-	for {
-		pv, ok := seq.next()
-		if !ok {
-			break
-		}
-		withFeedback = append(withFeedback, gen.FormatPathValuesForReport(pv))
-		seq.admitFeedback(pv, withFeedback != nil)
+	pv, ok := seq.next()
+	if !ok {
+		t.Fatal("expected a candidate")
 	}
-	if !reflect.DeepEqual(baseline, withFeedback) {
-		t.Fatalf("admitFeedback altered the sequence: got %v, want %v", withFeedback, baseline)
+	if got := gen.smartExplorer.CorpusLen(); got != 0 {
+		t.Fatalf("next() grew the corpus: CorpusLen() = %d, want 0 (before any admitFeedback)", got)
+	}
+
+	seq.admitFeedback(pv, true)
+	if got := gen.smartExplorer.CorpusLen(); got != 1 {
+		t.Fatalf("admitFeedback did not grow the corpus: CorpusLen() = %d, want 1", got)
+	}
+
+	before := gen.smartExplorer.CorpusLen()
+	if _, ok := seq.next(); !ok {
+		t.Fatal("expected a second candidate")
+	}
+	if got := gen.smartExplorer.CorpusLen(); got != before {
+		t.Fatalf("a later next() grew the corpus: CorpusLen() = %d, want %d (unchanged)", got, before)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Part of #54 (PR A of the multi-PR plan). `nextExplore`/`nextGuided` now only propose candidates — they no longer call `captureSignature()` or grow the corpus before the candidate has run.
- `admitFeedback` (called after `runIsolatedCase` actually executes the candidate) now performs that growth: `strategyPlain` grows `exploreCorpus`/`exploreSeenSigs`, `strategyCoverage`/`strategySmart` grow `guidedSeenSigs` and the respective explorer's corpus. Same novelty heuristic as before (`captureSignature`), just relocated to run after execution instead of before it.
- Dispatch (`sequence()`/`bounds()`/`runExecutionContext`) is untouched — already fully incremental for every `ExplorationMode`.
- No real coverage yet — that's PR B, which will replace the `captureSignature()` proxy with genuine per-iteration coverage data threaded through `proposalFeedback`.

## Tests
- Updated `TestPathSequence{Explore,Coverage,Smart}MatchesForEachForSameSeed` to drive the sequence via a new `collectSequenceWithFeedback` helper (interleaves `next()`+`admitFeedback()`, matching how `runExecutionContext` actually drives it) instead of plain `collectSequence`, since corpus growth is no longer synchronous with `next()`.
- Replaced `TestPathSequence{Explore,Coverage,Smart}AdmitFeedbackDoesNotAlterSequence` — that invariant is intentionally gone now — with `TestPathSequence{Explore,Coverage,Smart}CorpusGrowsOnlyAfterAdmitFeedback`, which asserts directly: zero corpus growth during `next()`, exact growth after `admitFeedback()`. This freezes the architectural boundary PR B needs.
- Cartesian/Sample tests (`AdmitFeedbackIsNoOpForCartesian`, `SampleAdmitFeedbackDoesNotAlterSequence`) untouched — those strategies have no feedback-dependent state.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full module)
- [x] `go test -race ./specs/...`