### PR TITLE
fix(specs): wire real per-candidate coverage into Coverage/Smart explorers

### DIFF
--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -248,6 +248,16 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep report
 		gen := plan.PathGens[i]
 		seq := gen.sequence()
 		maxAttempts, maxAccepted, maxRejections := gen.bounds()
+		// wantsCoverage is true only for the two strategies that actually consume Coverage
+		// (CoverageExplorer/SmartExplorer's Feedback) — allocating and hitting a 64KB bitmap per
+		// candidate for Cartesian/Sample/plain-Explore, which never look at it, would be pure waste.
+		wantsCoverage := gen.mode == ExplorationGuided && (gen.strategy == strategyCoverage || gen.strategy == strategySmart)
+		// lastCoverage hands the Coverage collected by Execute to AdmitFeedback for the same
+		// candidate. proposalController.Run calls them back-to-back with no concurrency in between
+		// (see its doc comment: "no parallel execution option"), so a closure variable is safe —
+		// keeping Coverage out of proposalCandidate/proposalFeedback keeps the controller itself
+		// generic instead of coupling it to path-generation concerns.
+		var lastCoverage *Coverage
 		return newProposalController(proposalControllerConfig{
 			MaxAttempts:   maxAttempts,
 			MaxAccepted:   maxAccepted,
@@ -260,12 +270,17 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep report
 				// executions actually happened, how long the suite really took, and where a
 				// failure occurred.
 				started := reportSpecStarted(rep, name, path)
-				result := runIsolatedCase(backend, program, candidate.Values)
+				var cov *Coverage
+				if wantsCoverage {
+					cov = &Coverage{}
+				}
+				result := runIsolatedCase(backend, program, candidate.Values, cov)
 				reportSpecFinished(rep, started, specResult{Failed: result.Failed})
+				lastCoverage = cov
 				return !result.Failed
 			},
 			AdmitFeedback: func(feedback proposalFeedback) {
-				seq.admitFeedback(feedback.Candidate.Values, feedback.Passed)
+				seq.admitFeedback(feedback.Candidate.Values, feedback.Passed, lastCoverage)
 			},
 		}).Run(runCtx)
 	}
@@ -451,23 +466,27 @@ type isolatedCaseResult struct {
 }
 
 // runIsolatedCase executes real generated cases in a subtest so Fatal and FailNow
-// terminate only that case while preserving the parent test's failure semantics.
-func runIsolatedCase(backend testBackend, program []Instruction, path PathValues) (result isolatedCaseResult) {
+// terminate only that case while preserving the parent test's failure semantics. cov, when
+// non-nil, is wired into the Context so assertions executed by program record real coverage
+// into it (see Context.RecordCoverage) — the caller owns the pointer and reads it back directly,
+// nothing needs to be copied out before the Context is returned to the pool.
+func runIsolatedCase(backend testBackend, program []Instruction, path PathValues, cov *Coverage) (result isolatedCaseResult) {
 	if real, ok := backend.(*runnableBackend); ok {
 		real.Run("generated", func(tb testing.TB) {
 			caseBackend := asTestBackend(tb)
 			defer putTestBackend(caseBackend)
 			defer func() { result.Failed = result.Failed || tb.Failed() }()
-			result = runIsolatedCaseDirect(caseBackend, program, path)
+			result = runIsolatedCaseDirect(caseBackend, program, path, cov)
 		})
 		return result
 	}
-	return runIsolatedCaseDirect(backend, program, path)
+	return runIsolatedCaseDirect(backend, program, path, cov)
 }
 
-func runIsolatedCaseDirect(backend testBackend, program []Instruction, path PathValues) (result isolatedCaseResult) {
+func runIsolatedCaseDirect(backend testBackend, program []Instruction, path PathValues, cov *Coverage) (result isolatedCaseResult) {
 	ctx := contextPool.Get().(*Context)
 	ctx.Reset(backend)
+	ctx.coverage = cov
 	ctx.SetPathValues(path)
 	result.Path = ctx.Path().clone()
 

--- a/specs/execution_plan_test.go
+++ b/specs/execution_plan_test.go
@@ -38,7 +38,7 @@ func TestGeneratedCaseLifecycle(t *testing.T) {
 			{Code: OpBody, Fn: func(ctx *Context) { order = append(order, "body") }},
 			{Code: OpAfterHook, Fn: func(ctx *Context) { order = append(order, "after-inner") }},
 			{Code: OpAfterHook, Fn: func(ctx *Context) { order = append(order, "after-outer") }},
-		}, PathValues{})
+		}, PathValues{}, nil)
 		if got, want := fmt.Sprint(order), "[before body after-inner after-outer]"; got != want {
 			t.Fatalf("hook order = %s, want %s", got, want)
 		}
@@ -56,7 +56,7 @@ func TestGeneratedCaseLifecycle(t *testing.T) {
 		result := runIsolatedCase(backend, []Instruction{
 			{Code: OpBody, Fn: func(ctx *Context) { ctx.Expect(false).ToEqual(true) }},
 			{Code: OpAfterHook, Fn: func(*Context) { afterRuns++ }},
-		}, PathValues{})
+		}, PathValues{}, nil)
 		if !result.Failed || afterRuns != 1 {
 			t.Fatalf("result = %#v, errors = %v, after runs = %d", result, backend.errors, afterRuns)
 		}
@@ -68,7 +68,7 @@ func TestGeneratedCaseLifecycle(t *testing.T) {
 		result := runIsolatedCase(backend, []Instruction{
 			{Code: OpBody, Fn: func(ctx *Context) { ctx.backend.FailNow(); bodyCompleted = true }},
 			{Code: OpAfterHook, Fn: func(*Context) { afterRuns = true }},
-		}, PathValues{})
+		}, PathValues{}, nil)
 		if !result.Failed || !backend.failNow || bodyCompleted || !afterRuns || result.Panic != nil {
 			t.Fatalf("result = %#v, failNow = %t, body completed = %t, after ran = %t", result, backend.failNow, bodyCompleted, afterRuns)
 		}
@@ -80,7 +80,7 @@ func TestGeneratedCaseLifecycle(t *testing.T) {
 		result := runIsolatedCase(backend, []Instruction{
 			{Code: OpBody, Fn: func(*Context) { panic("body panic") }},
 			{Code: OpAfterHook, Fn: func(*Context) { afterRuns++ }},
-		}, PathValues{})
+		}, PathValues{}, nil)
 		if got, want := result.Panic, any("body panic"); got != want || afterRuns != 1 {
 			t.Fatalf("panic = %#v, after runs = %d", got, afterRuns)
 		}
@@ -89,9 +89,9 @@ func TestGeneratedCaseLifecycle(t *testing.T) {
 	t.Run("shrink probe retains original values deterministically", func(t *testing.T) {
 		path := PathValues{values: []any{7}, present: []bool{true}, index: map[string]int{"value": 0}}
 		program := []Instruction{{Code: OpBody, Fn: func(*Context) {}}, {Code: OpAfterHook, Fn: func(*Context) {}}}
-		first := runIsolatedCase(&controlledBackend{}, program, path)
+		first := runIsolatedCase(&controlledBackend{}, program, path, nil)
 		path.values[0] = 9
-		second := runIsolatedCase(&controlledBackend{}, program, path)
+		second := runIsolatedCase(&controlledBackend{}, program, path, nil)
 		if first.Path.Int("value") != 7 || second.Path.Int("value") != 9 || first.Failed != second.Failed || first.Panic != second.Panic {
 			t.Fatalf("first = %#v, second = %#v", first, second)
 		}
@@ -422,6 +422,51 @@ func TestRunExecutionContextSmartStopsGeneratingOnCancelMidRun(t *testing.T) {
 	}
 	if considered != 1 {
 		t.Fatalf("candidates considered = %d, want 1 — generation must not run ahead of execution", considered)
+	}
+}
+
+// TestRunExecutionContextCoverageGrowsCorpusFromRealCoverage is #54's end-to-end proof for
+// strategyCoverage: real coverage recorded by an assertion running inside the executed case (not
+// a synthetic Coverage fed directly into admitFeedback, as in
+// TestPathSequenceCoverageCorpusGrowsOnlyAfterAdmitFeedback) must actually flow through
+// runIsolatedCase -> ctx.RecordCoverage -> admitFeedback -> CoverageExplorer.Feedback and grow the
+// corpus. EqualTo(ctx, v, v) records an edge whose hash depends on v itself (see
+// coverageEdgeHash/valueHash), so distinct candidate values are near-certain to look like novel
+// coverage — if the wiring were broken (e.g. cov never reaching ctx, or always compared as if
+// identical), the corpus would stay at 0 or 1 regardless of how many candidates ran.
+func TestRunExecutionContextCoverageGrowsCorpusFromRealCoverage(t *testing.T) {
+	const iterations = 20
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 1000}}},
+		nil, 0, 42, true, 0, iterations, 0)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(ctx *Context) {
+			v := ctx.Path().Int("value")
+			EqualTo(ctx, v, v)
+		}}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	runExecutionContext(context.Background(), &controlledBackend{}, nil, plan, 0)
+	if got := gen.coverageExplorer.CorpusLen(); got <= 1 {
+		t.Fatalf("CoverageExplorer corpus = %d, want > 1 — real per-candidate coverage from the executed assertion should have grown it past the seed", got)
+	}
+}
+
+// TestRunExecutionContextSmartGrowsCorpusFromRealCoverage is
+// TestRunExecutionContextCoverageGrowsCorpusFromRealCoverage's counterpart for strategySmart.
+func TestRunExecutionContextSmartGrowsCorpusFromRealCoverage(t *testing.T) {
+	const iterations = 20
+	gen := newPathGenerator([]PathVar{{Name: "value", rangeSpec: &intRange{min: 0, max: 1000}}},
+		nil, 0, 42, true, 0, 0, iterations)
+	plan := &ExecutionPlan{
+		Instructions: []Instruction{{Code: OpBody, Fn: func(ctx *Context) {
+			v := ctx.Path().Int("value")
+			EqualTo(ctx, v, v)
+		}}},
+		ProgramStart: []int{0}, ProgramLen: []int{1}, PathGens: []*PathGenerator{gen},
+	}
+	runExecutionContext(context.Background(), &controlledBackend{}, nil, plan, 0)
+	if got := gen.smartExplorer.CorpusLen(); got <= 1 {
+		t.Fatalf("SmartExplorer corpus = %d, want > 1 — real per-candidate coverage from the executed assertion should have grown it past the seed", got)
 	}
 }
 

--- a/specs/path_generator.go
+++ b/specs/path_generator.go
@@ -351,18 +351,18 @@ type pathSequence struct {
 	exploreSeenSigs    map[uint64]struct{}
 
 	// ExploreCoverage/ExploreSmart: mirrors runGuidedExploration's state one call to next() at a
-	// time. Unlike exploreSeenSigs above, guidedSeenSigs is the only local copy needed — NextInput
-	// is a fixed method on CoverageExplorer/SmartExplorer that always reads that explorer's own
-	// e.corpus field, so corpus growth must write directly into g.coverageExplorer.corpus /
-	// g.smartExplorer.corpus (the same real corpus runGuidedExploration grows) rather than a local
-	// copy; there is no g.corpus-equivalent field to avoid contaminating for these two strategies.
-	// guidedSeenSigs stays local so a direct ForEach call and an incremental sequence() walk never
-	// share (and corrupt) the same signature set — same discipline as exploreSeenSigs vs g.seenSigs.
+	// time. NextInput is a fixed method on CoverageExplorer/SmartExplorer that always reads that
+	// explorer's own e.corpus field, so corpus growth writes directly into
+	// g.coverageExplorer.corpus/g.smartExplorer.corpus (the same real corpus runGuidedExploration
+	// grows) — there is no g.corpus-equivalent field to avoid contaminating for these two
+	// strategies. Unlike strategyPlain, growth here is driven by genuine coverage novelty
+	// (CoverageExplorer.Feedback/SmartExplorer.Feedback, called from admitFeedback with the
+	// Coverage recorded by the candidate's actual execution) rather than a local signature set, so
+	// no local dedup state is needed here.
 	// guidedAttempts/guidedMaxAttempts cap the internal retry loop, same reasoning as Explore (#18).
 	guidedExecuted    int
 	guidedAttempts    int
 	guidedMaxAttempts int
-	guidedSeenSigs    map[uint64]struct{}
 }
 
 // sequence returns a pathSequence for g, incremental for every ExplorationMode (Cartesian,
@@ -403,7 +403,6 @@ func (g *PathGenerator) sequence() *pathSequence {
 			seq.exploreSeenSigs = make(map[uint64]struct{})
 			seq.exploreMaxAttempts = maxAttempts
 		case strategyCoverage, strategySmart:
-			seq.guidedSeenSigs = make(map[uint64]struct{})
 			seq.guidedMaxAttempts = maxAttempts
 		}
 		if g.iterations <= 0 {
@@ -626,18 +625,25 @@ func (s *pathSequence) advance() bool {
 // still reject it), so corpus growth belongs here, after runIsolatedCase has genuinely executed
 // it. Cartesian and Sample stay no-ops: neither has feedback-dependent state.
 //
-// Growth is still driven by captureSignature()'s call-site novelty proxy, not by passed — that
-// part of the heuristic is unchanged, only moved to run after execution instead of before it.
-// captureSignature() is called from this one fixed call site for every admitted candidate across
-// the whole sequence, so — same as it always was when called from nextExplore/nextGuided — it
-// yields the same signature every time within one sequence: exploreCorpus grows by the seed
-// candidate plus the first admitted candidate, and the guided corpus grows by exactly the first
-// admitted candidate. That's the existing, documented heuristic limitation (see nextGuided's doc
-// comment and #54), not something introduced here.
+// strategyPlain still grows exploreCorpus from captureSignature()'s call-site novelty proxy — #54
+// only wires real coverage into the two strategies actually named CoverageExplorer/SmartExplorer;
+// plain Explore has no coverage concept to draw on, so it keeps its existing heuristic unchanged,
+// just moved to run after execution instead of before it (same limitation as before: since
+// captureSignature() is called from this one fixed call site for every admitted candidate,
+// exploreCorpus grows by the seed candidate plus exactly the first admitted candidate).
 //
-// Wiring passed (or real per-iteration coverage) into corpus growth is exactly what #54 tracks as
-// the next step, now that growth has a real post-execution hook to react from.
-func (s *pathSequence) admitFeedback(candidate PathValues, passed bool) {
+// strategyCoverage/strategySmart now grow from cov, the real per-candidate Coverage collected by
+// runIsolatedCaseDirect while candidate actually ran (see runExecutionContext's Execute closure,
+// which allocates it, and CoverageExplorer.Feedback/SmartExplorer.Feedback, which decide novelty
+// by comparing cov against everything seen across the whole run so far) — not the captureSignature
+// proxy runGuidedExploration's ForEach-compatibility path still uses (that path never executes a
+// real case, so it has no Coverage to offer; see its doc comment). cov is nil when the caller
+// didn't collect coverage for this candidate; both Feedback methods are nil-safe no-ops then.
+//
+// passed still doesn't affect growth for any strategy: a failing candidate's coverage is feedback
+// too (see proposalFeedback's doc comment), and ForEach's compatibility path never considered
+// pass/fail either, so this preserves that semantics rather than introducing a new one.
+func (s *pathSequence) admitFeedback(candidate PathValues, passed bool, cov *Coverage) {
 	if s == nil || s.g == nil || s.g.mode != ExplorationGuided {
 		return
 	}
@@ -648,16 +654,10 @@ func (s *pathSequence) admitFeedback(candidate PathValues, passed bool) {
 			s.exploreSeenSigs[sig] = struct{}{}
 			s.exploreCorpus = append(s.exploreCorpus, candidate.clone())
 		}
-	case strategyCoverage, strategySmart:
-		sig := captureSignature()
-		if _, seen := s.guidedSeenSigs[sig]; !seen {
-			s.guidedSeenSigs[sig] = struct{}{}
-			if s.g.strategy == strategyCoverage {
-				s.g.coverageExplorer.corpus.Add(candidate)
-			} else {
-				s.g.smartExplorer.corpus.Add(candidate)
-			}
-		}
+	case strategyCoverage:
+		s.g.coverageExplorer.Feedback(candidate, cov)
+	case strategySmart:
+		s.g.smartExplorer.Feedback(candidate, cov)
 	}
 }
 
@@ -825,11 +825,15 @@ func (g *PathGenerator) runExploration(fn func(PathValues)) {
 // this method at all.
 //
 // Real coverage-guided corpus growth needs ctx.coverage populated with genuine assertion-level edge
-// data on every iteration, which requires wiring the runner to set it per path iteration — not yet
-// done (see nextGuided's doc comment). So, same as nextGuided, this method's corpus growth still
-// uses the call-site-signature novelty heuristic (captureSignature) as an honest, documented proxy —
-// good enough to give NextInput something to mutate from instead of always falling back to fully
-// random input, but not genuine coverage-guided selection.
+// data from an actual case execution — that's now wired for the dispatch path (runExecutionContext
+// allocates a Coverage per candidate, runIsolatedCaseDirect attaches it to ctx during the run, and
+// pathSequence.admitFeedback feeds it to CoverageExplorer.Feedback/SmartExplorer.Feedback). This
+// method has no such execution to draw coverage from — fn here is an arbitrary caller-supplied
+// callback, not a case that runs assertions against a Context — so it keeps the call-site-signature
+// novelty heuristic (captureSignature) as an honest, documented proxy: good enough to give NextInput
+// something to mutate from instead of always falling back to fully random input, but not genuine
+// coverage-guided selection. This is why TestPathSequence{Coverage,Smart}MatchesForEachForSameSeed
+// were removed in #54's PR B — the two paths now grow their corpus by genuinely different criteria.
 func (g *PathGenerator) runGuidedExploration(fn func(PathValues), nextInput func(*PathGenerator) PathValues, corpus *Corpus) {
 	executed := 0
 	for executed < g.iterations {

--- a/specs/path_generator_test.go
+++ b/specs/path_generator_test.go
@@ -28,10 +28,14 @@ func collectForEach(g *PathGenerator) []string {
 }
 
 // collectSequenceWithFeedback drains a pathSequence like collectSequence, but — matching how
-// runExecutionContext actually drives a sequence in production — calls admitFeedback(pv, true)
-// right after each next(), before proposing the next candidate. For Explore/Coverage/Smart this
-// interleaving is what makes their incremental corpus growth line up with ForEach's synchronous
-// growth timing; plain collectSequence (no feedback) leaves their corpus frozen at the seed.
+// runExecutionContext actually drives a sequence in production — calls admitFeedback(pv, true, nil)
+// right after each next(), before proposing the next candidate. For strategyPlain (Explore) this
+// interleaving is what makes its incremental corpus growth line up with ForEach's synchronous
+// growth timing; plain collectSequence (no feedback) leaves its corpus frozen at the seed. The nil
+// Coverage is correct here: this helper never executes a real case, so it has no real coverage to
+// report, matching strategyPlain (which ignores cov) but making this helper unusable for
+// strategyCoverage/strategySmart parity — see their corpus-growth tests instead, which use real
+// synthetic Coverage values.
 func collectSequenceWithFeedback(g *PathGenerator) []string {
 	seq := g.sequence()
 	var got []string
@@ -41,7 +45,7 @@ func collectSequenceWithFeedback(g *PathGenerator) []string {
 			break
 		}
 		got = append(got, g.FormatPathValuesForReport(pv))
-		seq.admitFeedback(pv, true)
+		seq.admitFeedback(pv, true, nil)
 	}
 	return got
 }
@@ -93,8 +97,8 @@ func TestPathSequenceAdmitFeedbackIsNoOpForCartesian(t *testing.T) {
 	gen := newPathGenerator([]PathVar{{Name: "x", Values: []any{1, 2}}}, nil, 0, 0, false, 0, 0, 0)
 	seq := gen.sequence()
 	before, _ := seq.next()
-	seq.admitFeedback(before, true)
-	seq.admitFeedback(before, false)
+	seq.admitFeedback(before, true, nil)
+	seq.admitFeedback(before, false, nil)
 	after, ok := seq.next()
 	if !ok {
 		t.Fatal("expected a second candidate")
@@ -213,7 +217,7 @@ func TestPathSequenceSampleAdmitFeedbackDoesNotAlterSequence(t *testing.T) {
 			break
 		}
 		withFeedback = append(withFeedback, gen.FormatPathValuesForReport(pv))
-		seq.admitFeedback(pv, withFeedback != nil)
+		seq.admitFeedback(pv, withFeedback != nil, nil)
 	}
 	if !reflect.DeepEqual(baseline, withFeedback) {
 		t.Fatalf("admitFeedback altered the sequence: got %v, want %v", withFeedback, baseline)
@@ -304,7 +308,7 @@ func TestPathSequenceExploreCorpusGrowsOnlyAfterAdmitFeedback(t *testing.T) {
 		t.Fatalf("next() grew the corpus: len(exploreCorpus) = %d, want 1 (seed only, before any admitFeedback)", got)
 	}
 
-	seq.admitFeedback(pv, true)
+	seq.admitFeedback(pv, true, nil)
 	if got := len(seq.exploreCorpus); got != 2 {
 		t.Fatalf("admitFeedback did not grow the corpus: len(exploreCorpus) = %d, want 2 (seed + admitted candidate)", got)
 	}
@@ -328,22 +332,6 @@ func TestPathSequenceCoverageEmitsExactlyRequestedIterations(t *testing.T) {
 	got := collectSequence(gen)
 	if len(got) != iterations {
 		t.Fatalf("len(got) = %d, want %d", len(got), iterations)
-	}
-}
-
-func TestPathSequenceCoverageMatchesForEachForSameSeed(t *testing.T) {
-	newGen := func() *PathGenerator {
-		return newPathGenerator([]PathVar{
-			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
-		}, nil, 0, 42, true, 0, 6, 0)
-	}
-
-	// See TestPathSequenceExploreMatchesForEachForSameSeed: growth moved to admitFeedback, so the
-	// comparison must interleave it the way production dispatch does.
-	got := collectSequenceWithFeedback(newGen())
-	want := collectForEach(newGen())
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("sequence-based ExploreCoverage = %v, want %v (must match runGuidedExploration exactly for the same seed)", got, want)
 	}
 }
 
@@ -384,8 +372,12 @@ func TestPathSequenceCoverageBoundsIsExact(t *testing.T) {
 	}
 }
 
-// TestPathSequenceCoverageCorpusGrowsOnlyAfterAdmitFeedback mirrors the Explore case: nextGuided
-// must not grow the CoverageExplorer's corpus itself; only admitFeedback does, after execution.
+// TestPathSequenceCoverageCorpusGrowsOnlyAfterAdmitFeedback is #54 PR B's core invariant for
+// strategyCoverage: nextGuided must never grow the CoverageExplorer's corpus itself, and growth
+// through admitFeedback must be driven by genuine coverage novelty (CoverageExplorer.Feedback +
+// Coverage.HasNewCoverage) rather than merely "an admitFeedback call happened" — so this uses real
+// synthetic Coverage values built with Coverage.Hit, the same primitive real assertions record
+// coverage through in production (see Context.RecordCoverage).
 func TestPathSequenceCoverageCorpusGrowsOnlyAfterAdmitFeedback(t *testing.T) {
 	gen := newPathGenerator([]PathVar{
 		{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
@@ -400,17 +392,29 @@ func TestPathSequenceCoverageCorpusGrowsOnlyAfterAdmitFeedback(t *testing.T) {
 		t.Fatalf("next() grew the corpus: CorpusLen() = %d, want 0 (before any admitFeedback)", got)
 	}
 
-	seq.admitFeedback(pv, true)
+	novel := &Coverage{}
+	novel.Hit(1)
+	seq.admitFeedback(pv, true, novel)
 	if got := gen.coverageExplorer.CorpusLen(); got != 1 {
-		t.Fatalf("admitFeedback did not grow the corpus: CorpusLen() = %d, want 1", got)
+		t.Fatalf("admitFeedback with novel coverage did not grow the corpus: CorpusLen() = %d, want 1", got)
 	}
 
-	before := gen.coverageExplorer.CorpusLen()
-	if _, ok := seq.next(); !ok {
+	pv2, ok := seq.next()
+	if !ok {
 		t.Fatal("expected a second candidate")
 	}
-	if got := gen.coverageExplorer.CorpusLen(); got != before {
-		t.Fatalf("a later next() grew the corpus: CorpusLen() = %d, want %d (unchanged)", got, before)
+	seq.admitFeedback(pv2, true, novel)
+	if got := gen.coverageExplorer.CorpusLen(); got != 1 {
+		t.Fatalf("admitFeedback with already-seen coverage grew the corpus: CorpusLen() = %d, want 1 (unchanged)", got)
+	}
+
+	pv3, ok := seq.next()
+	if !ok {
+		t.Fatal("expected a third candidate")
+	}
+	seq.admitFeedback(pv3, true, nil)
+	if got := gen.coverageExplorer.CorpusLen(); got != 1 {
+		t.Fatalf("admitFeedback with nil coverage grew the corpus: CorpusLen() = %d, want 1 (unchanged, nil-safe)", got)
 	}
 }
 
@@ -423,22 +427,6 @@ func TestPathSequenceSmartEmitsExactlyRequestedIterations(t *testing.T) {
 	got := collectSequence(gen)
 	if len(got) != iterations {
 		t.Fatalf("len(got) = %d, want %d", len(got), iterations)
-	}
-}
-
-func TestPathSequenceSmartMatchesForEachForSameSeed(t *testing.T) {
-	newGen := func() *PathGenerator {
-		return newPathGenerator([]PathVar{
-			{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
-		}, nil, 0, 42, true, 0, 0, 6)
-	}
-
-	// See TestPathSequenceExploreMatchesForEachForSameSeed: growth moved to admitFeedback, so the
-	// comparison must interleave it the way production dispatch does.
-	got := collectSequenceWithFeedback(newGen())
-	want := collectForEach(newGen())
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("sequence-based ExploreSmart = %v, want %v (must match runGuidedExploration exactly for the same seed)", got, want)
 	}
 }
 
@@ -479,8 +467,10 @@ func TestPathSequenceSmartBoundsIsExact(t *testing.T) {
 	}
 }
 
-// TestPathSequenceSmartCorpusGrowsOnlyAfterAdmitFeedback mirrors the Explore/Coverage cases:
-// nextGuided must not grow the SmartExplorer's corpus itself; only admitFeedback does.
+// TestPathSequenceSmartCorpusGrowsOnlyAfterAdmitFeedback mirrors the Coverage case for
+// strategySmart: nextGuided must never grow the SmartExplorer's corpus itself, and growth through
+// admitFeedback must be driven by genuine coverage novelty (SmartExplorer.Feedback +
+// Coverage.HasNewCoverage), not merely "an admitFeedback call happened."
 func TestPathSequenceSmartCorpusGrowsOnlyAfterAdmitFeedback(t *testing.T) {
 	gen := newPathGenerator([]PathVar{
 		{Name: "x", rangeSpec: &intRange{min: 0, max: 50}},
@@ -495,17 +485,29 @@ func TestPathSequenceSmartCorpusGrowsOnlyAfterAdmitFeedback(t *testing.T) {
 		t.Fatalf("next() grew the corpus: CorpusLen() = %d, want 0 (before any admitFeedback)", got)
 	}
 
-	seq.admitFeedback(pv, true)
+	novel := &Coverage{}
+	novel.Hit(1)
+	seq.admitFeedback(pv, true, novel)
 	if got := gen.smartExplorer.CorpusLen(); got != 1 {
-		t.Fatalf("admitFeedback did not grow the corpus: CorpusLen() = %d, want 1", got)
+		t.Fatalf("admitFeedback with novel coverage did not grow the corpus: CorpusLen() = %d, want 1", got)
 	}
 
-	before := gen.smartExplorer.CorpusLen()
-	if _, ok := seq.next(); !ok {
+	pv2, ok := seq.next()
+	if !ok {
 		t.Fatal("expected a second candidate")
 	}
-	if got := gen.smartExplorer.CorpusLen(); got != before {
-		t.Fatalf("a later next() grew the corpus: CorpusLen() = %d, want %d (unchanged)", got, before)
+	seq.admitFeedback(pv2, true, novel)
+	if got := gen.smartExplorer.CorpusLen(); got != 1 {
+		t.Fatalf("admitFeedback with already-seen coverage grew the corpus: CorpusLen() = %d, want 1 (unchanged)", got)
+	}
+
+	pv3, ok := seq.next()
+	if !ok {
+		t.Fatal("expected a third candidate")
+	}
+	seq.admitFeedback(pv3, true, nil)
+	if got := gen.smartExplorer.CorpusLen(); got != 1 {
+		t.Fatalf("admitFeedback with nil coverage grew the corpus: CorpusLen() = %d, want 1 (unchanged, nil-safe)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

PR B of #54 (PR A: #79). Replaces the `captureSignature()` proxy with real per-candidate coverage for `strategyCoverage`/`strategySmart` only — plain `Explore` keeps its own heuristic untouched.

- `admitFeedback(candidate, passed, cov *Coverage)`: for `strategyCoverage`/`strategySmart`, calls `CoverageExplorer.Feedback`/`SmartExplorer.Feedback` with the real `Coverage` recorded by the candidate's actual execution, instead of the call-stack-hash proxy. `strategyPlain` is unchanged.
- `runIsolatedCase`/`runIsolatedCaseDirect(..., cov *Coverage)`: wires `cov` into `ctx.coverage` before the case runs, so assertions (`EqualTo`, `Expectation.To/ToEqual`) record real coverage via `Context.RecordCoverage`.
- `runExecutionContext`: allocates `&Coverage{}` only for strategies that consume it (`wantsCoverage`), threads it from `Execute` to `AdmitFeedback` via a closure variable (`lastCoverage`) — safe because the two run strictly sequentially per candidate inside `proposalController.Run`, never concurrently.
- Removed `TestPathSequenceCoverageMatchesForEachForSameSeed`/`...Smart...`: that invariant (incremental sequence == ForEach output for the same seed) is now permanently false by design for these two strategies — the incremental path grows from real per-candidate coverage novelty, while ForEach's compatibility path (`runGuidedExploration`) never executes a real case and can only ever use the proxy.
- Rewrote `TestPathSequenceCoverage/SmartCorpusGrowsOnlyAfterAdmitFeedback` using real synthetic `Coverage` values (`Coverage.Hit`) to prove: `next()` never grows the corpus; novel coverage grows it by exactly 1; already-seen coverage does not grow it further; `nil` coverage is a safe no-op.
- Added `TestRunExecutionContextCoverage/SmartGrowsCorpusFromRealCoverage`: end-to-end proof that coverage recorded by a real assertion inside the executed case actually flows through `runIsolatedCase → ctx.RecordCoverage → admitFeedback → Feedback` and grows the corpus — not just a synthetic-`Coverage` unit test.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./specs/...`
- [x] `go test ./...` (full repo)
- [x] `go test -race ./specs/...`