### PR TITLE
fix: remove redundant aliased Builder/Runner API methods

### DIFF
--- a/specs/builder.go
+++ b/specs/builder.go
@@ -31,7 +31,7 @@ type specItem struct {
 	hookKey string // from b.hookKey() for coalescing without comparing funcs
 }
 
-// Builder compiles a DSL into a Program. Use NewBuilder(), then Describe/BeforeEach/AfterEach/It, then Program() or Build().
+// Builder compiles a DSL into a Program. Use NewBuilder(), then Describe/BeforeEach/AfterEach/It, then Build().
 type Builder struct {
 	program  *Program
 	scopes   []scope
@@ -95,7 +95,7 @@ func (b *Builder) Describe(name string, body func()) {
 	b.scopes = b.scopes[:len(b.scopes)-1]
 }
 
-// ensureScope ensures at least one scope exists (for flat AddBefore/AddAfter/AddSpec without Describe).
+// ensureScope ensures at least one scope exists (for BeforeEach/AfterEach/It used without Describe).
 func (b *Builder) ensureScope() {
 	if len(b.scopes) == 0 {
 		b.scopes = append(b.scopes, scope{})
@@ -280,29 +280,8 @@ func (b *Builder) finalize() {
 	b.program.Groups = groups
 }
 
-// Program returns the compiled program. Safe to call multiple times; do not modify the returned Program's Groups.
-func (b *Builder) Program() *Program {
-	b.finalize()
-	return b.program
-}
-
-// Build returns the compiled program. Same as Program(); kept for API compatibility with flat usage.
+// Build returns the compiled program. Safe to call multiple times; do not modify the returned Program's Groups.
 func (b *Builder) Build() *Program {
 	b.finalize()
 	return b.program
-}
-
-// AddBefore registers a hook to run before each spec (flat API, single scope). Same as BeforeEach in one implicit scope.
-func (b *Builder) AddBefore(fn func(*Context)) {
-	b.BeforeEach(fn)
-}
-
-// AddAfter registers a hook to run after each spec (flat API). Same as AfterEach in one implicit scope.
-func (b *Builder) AddAfter(fn func(*Context)) {
-	b.AfterEach(fn)
-}
-
-// AddSpec registers one spec (flat API). Same as It("", fn).
-func (b *Builder) AddSpec(fn func(*Context)) {
-	b.It("", fn)
 }

--- a/specs/compiled_runner_test.go
+++ b/specs/compiled_runner_test.go
@@ -5,20 +5,20 @@ import "testing"
 func TestCompiledRunner_OrderAndHooks(t *testing.T) {
 	var order []string
 	b := NewBuilder(32)
-	b.AddBefore(func(*Context) { order = append(order, "before1") })
-	b.AddBefore(func(*Context) { order = append(order, "before2") })
-	b.AddAfter(func(*Context) { order = append(order, "after1") })
-	b.AddAfter(func(*Context) { order = append(order, "after2") })
-	b.AddSpec(func(ctx *Context) {
+	b.BeforeEach(func(*Context) { order = append(order, "before1") })
+	b.BeforeEach(func(*Context) { order = append(order, "before2") })
+	b.AfterEach(func(*Context) { order = append(order, "after1") })
+	b.AfterEach(func(*Context) { order = append(order, "after2") })
+	b.It("", func(ctx *Context) {
 		order = append(order, "spec1")
 		EqualTo(ctx, 1, 1)
 	})
-	b.AddSpec(func(ctx *Context) {
+	b.It("", func(ctx *Context) {
 		order = append(order, "spec2")
 		EqualTo(ctx, 2, 2)
 	})
 	prog := b.Build()
-	runner := NewRunnerFromProgram(prog)
+	runner := NewRunner(prog)
 	runner.Run(t)
 
 	// Grouped execution: before once, all specs, after once (reverse)
@@ -37,8 +37,8 @@ func TestCompiledRunner_OrderAndHooks(t *testing.T) {
 
 func TestCompiledRunner_ZeroAllocs(t *testing.T) {
 	b := NewBuilder(8)
-	b.AddSpec(func(ctx *Context) { EqualTo(ctx, 42, 42) })
-	runner := NewRunnerFromProgram(b.Build())
+	b.It("", func(ctx *Context) { EqualTo(ctx, 42, 42) })
+	runner := NewRunner(b.Build())
 	var d testing.B
 	runner.Run(&d)
 	// Run should not allocate; check with go test -bench=BenchmarkRunner -benchmem

--- a/specs/program.go
+++ b/specs/program.go
@@ -35,7 +35,7 @@ type group struct {
 }
 
 // specName returns names[i], or "" when names doesn't cover index i (an unnamed spec, e.g. from
-// AddSpec, or a group that reports its own specs internally — see group.names).
+// It("", fn), or a group that reports its own specs internally — see group.names).
 func specName(names []string, i int) string {
 	if i < 0 || i >= len(names) {
 		return ""

--- a/specs/program_test.go
+++ b/specs/program_test.go
@@ -41,7 +41,7 @@ func TestProgram_DescribeBeforeEachIt(t *testing.T) {
 		b.BeforeEach(setup)
 		b.It("adds", testAdd)
 	})
-	prog := b.Program()
+	prog := b.Build()
 	if len(prog.Groups) != 1 || len(prog.Groups[0].before) != 1 || len(prog.Groups[0].specs) != 1 || len(prog.Groups[0].after) != 0 {
 		t.Fatalf("expected one group with before=1, specs=1, after=0; got %d groups", len(prog.Groups))
 	}
@@ -65,7 +65,7 @@ func TestProgram_GroupingBehavior(t *testing.T) {
 		b.It("add", testAdd)
 		b.It("sub", testSub)
 	})
-	prog := b.Program()
+	prog := b.Build()
 	if len(prog.Groups) != 1 {
 		t.Fatalf("expected 1 group; got %d", len(prog.Groups))
 	}
@@ -94,7 +94,7 @@ func TestProgram_NestedDescribeHooks(t *testing.T) {
 			b.It("b", func(*Context) { order = append(order, "it2") })
 		})
 	})
-	prog := b.Program()
+	prog := b.Build()
 	r := NewRunner(prog)
 	r.Run(t)
 	// Grouped: before once, all specs, after once (reverse)
@@ -114,13 +114,13 @@ func TestProgram_NestedDescribeHooks(t *testing.T) {
 func TestProgram_FlatAddBeforeAddSpecOrder(t *testing.T) {
 	var order []string
 	b := NewBuilder(32)
-	b.AddBefore(func(*Context) { order = append(order, "before1") })
-	b.AddBefore(func(*Context) { order = append(order, "before2") })
-	b.AddAfter(func(*Context) { order = append(order, "after1") })
-	b.AddAfter(func(*Context) { order = append(order, "after2") })
-	b.AddSpec(func(*Context) { order = append(order, "spec1") })
-	b.AddSpec(func(*Context) { order = append(order, "spec2") })
-	runner := NewRunnerFromProgram(b.Build())
+	b.BeforeEach(func(*Context) { order = append(order, "before1") })
+	b.BeforeEach(func(*Context) { order = append(order, "before2") })
+	b.AfterEach(func(*Context) { order = append(order, "after1") })
+	b.AfterEach(func(*Context) { order = append(order, "after2") })
+	b.It("", func(*Context) { order = append(order, "spec1") })
+	b.It("", func(*Context) { order = append(order, "spec2") })
+	runner := NewRunner(b.Build())
 	runner.Run(t)
 	// Grouped: before once, all specs, after once (reverse)
 	want := []string{
@@ -367,8 +367,8 @@ func TestProgram_ParallelGrouping(t *testing.T) {
 
 func TestProgram_FailFastStopsExecution(t *testing.T) {
 	b := NewBuilder()
-	b.AddSpec(func(ctx *Context) { EqualTo(ctx, 1, 1) })
-	b.AddSpec(func(ctx *Context) { EqualTo(ctx, 2, 2) })
+	b.It("", func(ctx *Context) { EqualTo(ctx, 1, 1) })
+	b.It("", func(ctx *Context) { EqualTo(ctx, 2, 2) })
 	prog := b.Build()
 	r := NewRunner(prog)
 	r.FailFast = true

--- a/specs/runner.go
+++ b/specs/runner.go
@@ -32,11 +32,6 @@ func NewRunner(program *Program) *Runner {
 	return &Runner{program: program}
 }
 
-// NewRunnerFromProgram is an alias for NewRunner; kept for API compatibility.
-func NewRunnerFromProgram(program *Program) *Runner {
-	return NewRunner(program)
-}
-
 // NewRunnerWithReporter creates a runner that reports SuiteStarted/SuiteFinished and
 // SpecStarted/SpecFinished events to rep as the program runs. name is used for
 // SuiteStartEvent/SuiteEndEvent.Name; if empty, the backend's name is used instead.


### PR DESCRIPTION
## Summary
- Removes `Builder.Program()` (identical duplicate of `Build()`), `Builder.AddBefore`/`AddAfter`/`AddSpec` (one-line forwards to `BeforeEach`/`AfterEach`/`It`), and `NewRunnerFromProgram` (identical duplicate of `NewRunner`).
- Deleted outright rather than deprecated, per the pre-1.0 status discussed in #21.
- Updates the in-repo call sites (`compiled_runner_test.go`, `program_test.go`) that used the removed names, plus a stale doc comment in `program.go`.
- `BCBuilder`'s own `AddBefore`/`AddAfter`/`AddSpec` are untouched — separate type, no `BeforeEach`/`AfterEach`/`It` counterpart, so not part of this redundancy.

Closes #36

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)