### PR TITLE
fix: extract acquireContext helper for contextPool get/reset/put boilerplate

### DIFF
--- a/specs/block_runner.go
+++ b/specs/block_runner.go
@@ -67,12 +67,8 @@ func (r *BlockRunner) Run(tb testing.TB) {
 	}
 	backend := asTestBackend(tb)
 	defer putTestBackend(backend)
-	ctx := contextPool.Get().(*Context)
-	defer func() {
-		ctx.Reset(nil)
-		contextPool.Put(ctx)
-	}()
-	ctx.Reset(backend)
+	ctx, release := acquireContext(backend)
+	defer release()
 	ctx.SetPathValues(PathValues{})
 
 	runBlocks(ctx, r.fns, r.blocks)

--- a/specs/context.go
+++ b/specs/context.go
@@ -11,13 +11,24 @@ import (
 )
 
 // contextPool reuses Context instances in the runner to reduce allocations.
-// The runner acquires with contextPool.Get().(*Context), calls Reset(backend), runs the spec,
-// then Reset(nil) to release references, and contextPool.Put(ctx). Do not retain Context
-// after Put; it may be reused.
+// Runners acquire via acquireContext(backend); do not retain a Context after releasing it back
+// to the pool, as it may be reused.
 var contextPool = sync.Pool{
 	New: func() any {
 		return &Context{}
 	},
+}
+
+// acquireContext gets a Context from contextPool, resets it for backend, and returns it along
+// with a release func that resets it again (to drop references) and returns it to the pool.
+// Callers should `defer release()` immediately.
+func acquireContext(backend testBackend) (*Context, func()) {
+	ctx := contextPool.Get().(*Context)
+	ctx.Reset(backend)
+	return ctx, func() {
+		ctx.Reset(nil)
+		contextPool.Put(ctx)
+	}
 }
 
 // expectationPool reuses Expectation instances for Expect(...).To() / ToEqual() to reduce allocations.

--- a/specs/execution_plan.go
+++ b/specs/execution_plan.go
@@ -284,11 +284,8 @@ func runExecutionContext(runCtx context.Context, backend testBackend, rep report
 			},
 		}).Run(runCtx)
 	}
-	ctx := contextPool.Get().(*Context)
-	defer func() {
-		ctx.Reset(nil)
-		contextPool.Put(ctx)
-	}()
+	ctx, release := acquireContext(backend)
+	defer release()
 	started := reportSpecStarted(rep, name, path)
 	message, output := runSpecProgram(backend, ctx, program, name)
 	reportSpecFinished(rep, started, specResult{Failed: ctx.failed, Message: message, Output: output})
@@ -484,8 +481,7 @@ func runIsolatedCase(backend testBackend, program []Instruction, path PathValues
 }
 
 func runIsolatedCaseDirect(backend testBackend, program []Instruction, path PathValues, cov *Coverage) (result isolatedCaseResult) {
-	ctx := contextPool.Get().(*Context)
-	ctx.Reset(backend)
+	ctx, release := acquireContext(backend)
 	ctx.coverage = cov
 	ctx.SetPathValues(path)
 	result.Path = ctx.Path().clone()
@@ -515,9 +511,8 @@ func runIsolatedCaseDirect(backend testBackend, program []Instruction, path Path
 			}()
 		}
 		result.Failed = result.Failed || ctx.failed
-		ctx.Reset(nil)
+		release()
 		result.ContextReset = true
-		contextPool.Put(ctx)
 	}()
 
 	for _, inst := range program {

--- a/specs/minimal_runner.go
+++ b/specs/minimal_runner.go
@@ -73,12 +73,8 @@ func (r *MinimalRunner) Run(tb testing.TB) {
 	}
 	backend := asTestBackend(tb)
 	defer putTestBackend(backend)
-	ctx := contextPool.Get().(*Context)
-	defer func() {
-		ctx.Reset(nil)
-		contextPool.Put(ctx)
-	}()
-	ctx.Reset(backend)
+	ctx, release := acquireContext(backend)
+	defer release()
 	ctx.SetPathValues(PathValues{})
 
 	runMinimalSpecs(ctx, r.specs)

--- a/specs/program.go
+++ b/specs/program.go
@@ -141,8 +141,7 @@ func parallelStep(steps []step, names []string) step {
 			go func() {
 				defer wg.Done()
 				backend := &parallelBackend{specIndex: i, results: &results, abortOnFatal: true}
-				child := contextPool.Get().(*Context)
-				child.Reset(backend)
+				child, release := acquireContext(backend)
 				child.SetPathValues(pathValues)
 				var started report.SpecStartEvent
 				if obs != nil {
@@ -164,8 +163,7 @@ func parallelStep(steps []step, names []string) step {
 					if obs != nil {
 						obs.specFinished(started, specResult{Failed: results[i] != "", Message: results[i]})
 					}
-					child.Reset(nil)
-					contextPool.Put(child)
+					release()
 				}()
 				s(child)
 			}()

--- a/specs/runner.go
+++ b/specs/runner.go
@@ -104,12 +104,8 @@ func (r *Runner) Run(tb testing.TB) {
 	}
 	backend := asTestBackend(tb)
 	defer putTestBackend(backend)
-	ctx := contextPool.Get().(*Context)
-	defer func() {
-		ctx.Reset(nil)
-		contextPool.Put(ctx)
-	}()
-	ctx.Reset(backend)
+	ctx, release := acquireContext(backend)
+	defer release()
 	ctx.SetPathValues(PathValues{})
 	if r.FailFast {
 		ctx.SetFailFast(true)

--- a/specs/runner_bytecode.go
+++ b/specs/runner_bytecode.go
@@ -36,12 +36,8 @@ func (r *BytecodeRunner) Run(tb testing.TB) {
 	}
 	backend := asTestBackend(tb)
 	defer putTestBackend(backend)
-	ctx := contextPool.Get().(*Context)
-	defer func() {
-		ctx.Reset(nil)
-		contextPool.Put(ctx)
-	}()
-	ctx.Reset(backend)
+	ctx, release := acquireContext(backend)
+	defer release()
 	ctx.SetPathValues(PathValues{})
 
 	runBytecodeSequential(ctx, r.program.Code, r.program.SpecStarts)
@@ -120,11 +116,8 @@ func (r *BytecodeRunner) RunParallel(tb failureReporter, workers int) {
 // runBytecodeWorker runs spec ranges whose spec index it acquires via next. One context per worker.
 // No allocations in the loop: context from pool, backend preallocated, code/starts read-only.
 func runBytecodeWorker(code []instruction, starts []int, nSpecs int, backend *parallelBackend, next *uint32, results *[]string) {
-	ctx := contextPool.Get().(*Context)
-	defer func() {
-		ctx.Reset(nil)
-		contextPool.Put(ctx)
-	}()
+	ctx, release := acquireContext(backend)
+	defer release()
 
 	for {
 		s := atomic.AddUint32(next, 1) - 1

--- a/specs/scheduler.go
+++ b/specs/scheduler.go
@@ -96,11 +96,8 @@ func (p *parallelBackend) Run(name string, fn func(testing.TB)) {
 // the whole worker lifetime; resets it per spec. Backend is the worker's dedicated parallelBackend.
 // No allocations in the loop: context from pool, backend is preallocated, specs slice is read-only.
 func runWorker(specs []RunSpec, backend *parallelBackend, next *uint32, results *[]string) {
-	ctx := contextPool.Get().(*Context)
-	defer func() {
-		ctx.Reset(nil)
-		contextPool.Put(ctx)
-	}()
+	ctx, release := acquireContext(backend)
+	defer release()
 
 	n := uint32(len(specs))
 	for {

--- a/specs/scheduler_batch.go
+++ b/specs/scheduler_batch.go
@@ -20,11 +20,8 @@ const DefaultChunkSize = 16
 // raised it (see runWorkerSpec) — the chunk loop continues to the next spec. No allocations in
 // the loop.
 func runWorkerBatched(specs []RunSpec, backend *parallelBackend, next *uint32, results *[]string, chunkSize uint32) {
-	ctx := contextPool.Get().(*Context)
-	defer func() {
-		ctx.Reset(nil)
-		contextPool.Put(ctx)
-	}()
+	ctx, release := acquireContext(backend)
+	defer release()
 
 	n := uint32(len(specs))
 	if chunkSize == 0 {


### PR DESCRIPTION
## Summary
- Adds `acquireContext(backend testBackend) (*Context, func())` in `context.go`, wrapping the `contextPool.Get()` / `ctx.Reset(backend)` / deferred `ctx.Reset(nil)` + `contextPool.Put(ctx)` sequence that was duplicated across 8 call sites.
- Updates `Runner.Run`, `BlockRunner.Run`, `MinimalRunner.Run`, `BytecodeRunner.Run`, `runBytecodeWorker`, `runWorker`, `runWorkerBatched`, `runExecutionContext`, `runIsolatedCaseDirect`, and `parallelStep`'s per-goroutine child context to use it.
- Two sites (the `runSpecProgram` path off `runExecutionContext`, and `runIsolatedCaseDirect`'s isolated-subtest branch) still reset `ctx` again internally with a possibly-different backend after acquisition — harmless, since `Context.Reset` isn't on the hot per-spec path in either case.

Closes #34

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass
- [x] `go test -race ./...` — clean
- [x] `go test ./benchmarks -bench=. -benchmem` — allocation counts unchanged from baseline (helper adds no allocations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)