### PR TITLE
docs: fix Makefile's nonexistent multi-module go.work layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
-# go-specs monorepo Makefile
-# Run from repository root with go.work enabled.
-# Note: ./... does not work at root (no root module); each module is built/tested explicitly.
-
-MODULES := ./assert/... ./specs/... ./report/... ./mock/... ./gen/... ./snapshots/... ./benchmarks/... ./examples/... ./tools/perfcheck/...
+# go-specs Makefile
+# Single Go module at the repository root; run targets from repo root.
 
 BENCH_RESULTS := benchmarks/results
 BENCHSTAT := $(shell go env GOPATH)/bin/benchstat
@@ -24,21 +21,21 @@ help:
 	@echo "  make bench-compare Compare previous.txt vs current.txt (benchstat)"
 	@echo "  make lint          Lint (golangci-lint or go vet)"
 	@echo "  make build         Build all modules and specs-cli"
-	@echo "  make tidy          go work sync and go mod tidy for all modules"
+	@echo "  make tidy          go mod tidy"
 	@echo "  make clean         Remove specs-cli, coverage.*, benchmark results"
 	@echo ""
 
-# Run tests across all modules
+# Run tests
 test:
-	go test $(MODULES)
+	go test ./...
 
 # Run tests with race detector
 test-race:
-	go test -race $(MODULES)
+	go test -race ./...
 
 # Run tests with coverage; report to stdout and write coverage.out
 coverage:
-	go test -coverprofile=coverage.out $(MODULES)
+	go test -coverprofile=coverage.out ./...
 	@go tool cover -func=coverage.out
 
 # Run benchmarks (quick run, output to terminal)
@@ -62,21 +59,13 @@ bench-compare:
 lint:
 	@which golangci-lint >/dev/null 2>&1 && golangci-lint run ./assert/... ./specs/... ./report/... ./mock/... ./gen/... ./snapshots/... ./benchmarks/... ./examples/... || (go vet ./assert/... ./specs/... ./report/... ./mock/... ./gen/... ./snapshots/... ./benchmarks/... ./examples/...)
 
-# Build all modules and the CLI
+# Build all packages
 build:
-	go build $(MODULES)
+	go build ./...
 
-# Tidy all modules
+# Tidy the module
 tidy:
-	go work sync
-	cd specs && go mod tidy
-	cd report && go mod tidy
-	cd mock && go mod tidy
-	cd assert && go mod tidy
-	cd snapshots && go mod tidy
-	cd gen && go mod tidy
-	cd examples && go mod tidy
-	cd tools/specs-cli && go mod tidy
+	go mod tidy
 
 clean:
 	rm -f specs-cli coverage.out coverage.html


### PR DESCRIPTION
## Summary
- The Makefile header claimed \"Run from repository root with go.work enabled\" and \"./... does not work at root (no root module)\"; `tidy` did `cd <dir> && go mod tidy` across 9 subdirectories (one, `tools/specs-cli`, doesn't exist). There is only one `go.mod`, at the repository root, and no `go.work` anywhere.
- Dropped the go.work/multi-module header comments.
- Simplified `tidy` to a single `go mod tidy` at the root.
- Replaced the explicit `MODULES` package list with `./...` in `test`, `test-race`, `coverage`, and `build` — verified identical package coverage and results.
- Left `lint` on its explicit package list: switching it to `./...` would newly include `tools/perfcheck`, which fails golangci-lint's errcheck check today — a pre-existing, unrelated issue outside this fix's scope.
- Left the `specs-cli` references in `build`/`clean`/`help` untouched; that drift is tracked separately (per #29's own note, alongside the ARCHITECTURE.md mismatch in #10).

Closes #29

## Test plan
- [x] `make build`
- [x] `make test`
- [x] `make test-race`
- [x] `make lint` — 0 issues
- [x] `make tidy` — no diff to `go.mod`/`go.sum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)