### PR TITLE
docs: add pre-1.0 status disclaimer and start CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project is pre-1.0, so any release may include breaking changes (see [README.md#project-status](README.md#project-status)).
+
+Entries for `v0.0.1`–`v0.0.9` predate this file — see [GitHub Releases](https://github.com/pablogore/go-specs/releases) for their auto-generated notes.
+
+## [Unreleased]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/pablogore/go-specs)](https://goreportcard.com/report/github.com/pablogore/go-specs)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
+## Project status
+
+go-specs is pre-1.0 (`v0.x`). The public API (`Describe`, `It`, `Context`, `Expectation`, `Mutator`, etc.) is still settling and may change without notice between releases. Pin an exact version and check [CHANGELOG.md](CHANGELOG.md) before upgrading.
+
 ## Description
 
 **go-specs** is a fast, deterministic BDD-style testing framework for Go. It provides an expressive DSL for writing readable tests while staying close to the standard library and avoiding reflection and allocation overhead. By default, suites run sequentially in declaration order with no hidden concurrency, so test results are stable and reproducible; opt-in parallel execution (`ItParallel`, `RunParallel`, `RunParallelBatched`) is available where throughput matters.


### PR DESCRIPTION
## Summary
- Adds a "Project status" section to README.md flagging the public API as pre-1.0 and subject to breaking changes without notice
- Starts CHANGELOG.md (Keep a Changelog format), pointing to existing GitHub Releases for v0.0.1–v0.0.9 history and tracking changes forward from here

Closes #21

## Test plan
- Docs-only change; no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)