### PR TITLE
chore: add supply-chain security tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,23 @@ jobs:
 
       - name: Test with race detector
         run: go test -race ./...
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+          cache: false  # avoid tar "File exists" when restoring cache with toolchain files
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+go-specs is pre-1.0 (see [README.md#project-status](README.md#project-status)). Only the latest tagged release is supported; please upgrade before reporting an issue.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately using [GitHub Security Advisories](https://github.com/pablogore/go-specs/security/advisories/new) for this repository, rather than opening a public issue.
+
+If that route is unavailable, open a regular issue without exploit details and ask for a private channel to share them.
+
+We aim to acknowledge reports within a few days and will credit reporters in the fix's release notes unless anonymity is requested.


### PR DESCRIPTION
## Summary
- Add a `govulncheck` job to `.github/workflows/ci.yml` (separate job, `stable` Go, runs `govulncheck ./...`)
- Add `.github/dependabot.yml` with weekly updates for the `gomod` and `github-actions` ecosystems
- Add `SECURITY.md` pointing to GitHub Security Advisories for private reports, scoped to the pre-1.0 status from #21

Closes #19

## Test plan
- Ran `govulncheck ./...` locally: 0 reachable vulnerabilities (5 import-level / 4 module-level vulns exist but aren't called by our code, so the check passes as CI will run it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)