### PR TITLE
docs: add pkg.go.dev Example functions for assert, mock, specs

### DIFF
--- a/assert/example_test.go
+++ b/assert/example_test.go
@@ -1,0 +1,61 @@
+package assert
+
+import "fmt"
+
+func ExampleEqual() {
+	m := Equal(42)
+	fmt.Println(m.Match(42))
+	fmt.Println(m.Match(43))
+	// Output:
+	// true
+	// false
+}
+
+func ExampleNotEqual() {
+	m := NotEqual(42)
+	fmt.Println(m.Match(42))
+	fmt.Println(m.Match(43))
+	// Output:
+	// false
+	// true
+}
+
+func ExampleBeNil() {
+	m := BeNil()
+	var p *int
+	fmt.Println(m.Match(nil))
+	fmt.Println(m.Match(p))
+	fmt.Println(m.Match(0))
+	// Output:
+	// true
+	// true
+	// false
+}
+
+func ExampleBeTrue() {
+	m := BeTrue()
+	fmt.Println(m.Match(true))
+	fmt.Println(m.Match(false))
+	// Output:
+	// true
+	// false
+}
+
+func ExampleBeFalse() {
+	m := BeFalse()
+	fmt.Println(m.Match(false))
+	fmt.Println(m.Match(true))
+	// Output:
+	// true
+	// false
+}
+
+func ExampleContain() {
+	fmt.Println(Contain("wor").Match("hello world"))
+	fmt.Println(Contain(3).Match([]int{1, 2, 3}))
+	fmt.Println(Contain(4).Match([]int{1, 2, 3}))
+	// Output:
+	// true
+	// true
+	// false
+}

--- a/mock/example_test.go
+++ b/mock/example_test.go
@@ -1,0 +1,16 @@
+package mock
+
+import "fmt"
+
+func ExampleSpy() {
+	spy := NewSpy()
+	spy.Call("user@example.com", 42)
+
+	fmt.Println(spy.CallCount())
+	fmt.Println(spy.CalledWith(Equal("user@example.com"), Any()))
+	fmt.Println(spy.CalledWith(Equal("someone-else@example.com"), Any()))
+	// Output:
+	// 1
+	// true
+	// false
+}

--- a/specs/example_test.go
+++ b/specs/example_test.go
@@ -1,0 +1,43 @@
+package specs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pablogore/go-specs/assert"
+)
+
+// ExampleDescribe and ExampleContext_Expect are not executed by `go test` (no "Output:" comment):
+// Describe requires a real *testing.T handed to it by the go test runner, and there is no way to
+// construct one — testing.TB's private() method is unexported precisely to stop external types
+// from satisfying it — from inside a parameterless Example function. They still compile on every
+// `go test` run, so a signature change here fails the build, and they still render on pkg.go.dev.
+
+func ExampleDescribe() {
+	var t *testing.T
+	Describe(t, "math", func(s *Spec) {
+		s.It("adds numbers", func(ctx *Context) {
+			ctx.Expect(1 + 1).ToEqual(2)
+		})
+	})
+}
+
+func ExampleContext_Expect() {
+	var t *testing.T
+	Describe(t, "strings", func(s *Spec) {
+		s.It("is not empty", func(ctx *Context) {
+			ctx.Expect(len("hello") > 0).To(assert.BeTrue())
+		})
+	})
+}
+
+// ExampleMutator_MutateInt is genuinely executed and Output-verified: Mutator needs no
+// *testing.T, and its RNG is deterministic for a given seed.
+func ExampleMutator_MutateInt() {
+	m := NewMutator(1)
+	fmt.Println(m.MutateInt(10, 0, 100))
+	fmt.Println(m.MutateInt(10, 0, 100))
+	// Output:
+	// 6
+	// 8
+}


### PR DESCRIPTION
## Summary
- `assert/example_test.go`: `ExampleEqual`, `ExampleNotEqual`, `ExampleBeNil`, `ExampleBeTrue`, `ExampleBeFalse`, `ExampleContain` — real, Output-verified (matchers are pure, no `*testing.T` needed)
- `mock/example_test.go`: `ExampleSpy` — real, Output-verified
- `specs/example_test.go`: `ExampleDescribe`, `ExampleContext_Expect` (compile-only, no `Output:` comment — see below), plus `ExampleMutator_MutateInt` (real, Output-verified: `Mutator` needs no `T`, and its RNG is deterministic per seed)

**Why `Describe`-based examples can't be Output-verified:** `Describe(tb testing.TB, ...)` needs a real `*testing.T`/`*testing.B`. `testing.TB` has an unexported `private()` method specifically so no external type can implement it, and I confirmed empirically that a zero-value `&testing.T{}` isn't a workaround — it panics inside `testing`'s own internals (`t.Deadline()` dereferences a nil parent) as soon as the spec tree runs. There is no legal way to obtain a working `testing.TB` inside a parameterless `func ExampleXxx()`. `ExampleDescribe`/`ExampleContext_Expect` are written without an `Output:` comment, which per Go's `testing` package means they're compiled on every `go test` run (catching signature drift) but never executed — the correct, standard way to document an API that structurally can't be example-run.

Closes #23

## Test plan
- `go build ./...` and `go vet ./...` pass
- `go test ./assert/... ./mock/... ./specs/... -run Example -v`: `ExampleEqual`, `ExampleNotEqual`, `ExampleBeNil`, `ExampleBeTrue`, `ExampleBeFalse`, `ExampleContain`, `ExampleSpy`, `ExampleMutator_MutateInt` all PASS; `ExampleDescribe`/`ExampleContext_Expect` correctly do not appear in the run (no Output comment) while still compiling
- Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)