### PR TITLE
docs(ci): confirm Shipwright canonical-CI gap analysis; no functional move needed yet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,23 +2,40 @@
 # go.mod requires go 1.25.0; the matrix covers that floor plus the latest stable release so
 # neither a too-old nor a too-new toolchain silently goes unchecked.
 #
-# The `shipwright` job runs unit tests, lint, and govulncheck as one
-# Dagger-backed workflow (.shipwright/workflow.yaml) with all three steps
-# executing in parallel instead of sequentially. It complements rather than
-# replaces the `test` matrix job below: Dagger only runs Linux containers,
-# so it cannot cover the macOS leg or pin an exact non-default Go version --
-# that matrix stays native. The unit-test step is deliberately redundant
-# with `test`'s ubuntu/stable leg; it's cheap because it runs in parallel
-# with lint/vuln anyway, and lint is new coverage this CI didn't have before.
+# The `shipwright` job runs unit tests (with race detection baked into the
+# go-test provider itself), lint, and govulncheck as one Dagger-backed
+# workflow (.shipwright/workflow.yaml) with all three steps executing in
+# parallel instead of sequentially. .shipwright/workflow.yaml is the
+# canonical definition of what "go-specs passes CI" means; this file only
+# adds what Shipwright cannot express today.
+#
+# Build and vet stay native because Shipwright has no provider for either
+# on a library module: its only `build` provider compiles a single `main`
+# binary from `.` (go-specs has none), and no `go-vet` provider is
+# registered anywhere in Shipwright -- golangci-lint's default linter set
+# already runs vet-equivalent checks, but that's implicit coverage, not a
+# vet gate a manifest can request directly (pablogore/shipwright#273,
+# pablogore/shipwright#274).
+#
+# The Go-version/OS matrix stays native for two independent reasons: Dagger
+# only runs Linux containers, so it structurally cannot cover the macOS
+# leg; and go-test's with-fields expose no Go-version knob (hardcoded to
+# provider's own default), so it can't be pointed at the 1.25 floor or an
+# arbitrary "stable" release either. The unit-test step (with -race) is
+# deliberately redundant with `test`'s ubuntu/stable leg; it's cheap
+# because it runs in parallel with lint/vuln anyway, and lint is coverage
+# this CI didn't have before Shipwright.
 #
 # The job downloads+verifies the pinned shipwright binary itself instead of
 # using pablogore/shipwright's own composite action: that action's v0.12.0
 # action.yml has an unrelated bug (a literal `${{ secrets.DAGGER_CLOUD_TOKEN
 # }}` inside an input's `description:` string, which GitHub's own template
 # validator rejects with "Unrecognized named-value: 'secrets'" while just
-# parsing the manifest -- confirmed on this repo's own PR checks). The steps
-# below replicate exactly what that action does (download -> verify
-# checksums.txt -> run), minus the broken manifest.
+# parsing the manifest -- confirmed on this repo's own PR checks, and
+# re-confirmed against the v0.12.0 tag and main tip on 2026-09-10,
+# pablogore/shipwright#275). The steps below replicate exactly what that
+# action does (download -> verify checksums.txt -> run), minus the broken
+# manifest.
 name: CI
 
 on:


### PR DESCRIPTION
## Goal

Move toward "Shipwright owns pipeline semantics, GitHub Actions only owns GitHub-specific bootstrap" for go-specs' CI, per the architectural direction discussed for this repo.

## What I found

I inspected `pablogore/shipwright` at `v0.12.0` (the version pinned in `.github/workflows/ci.yml`, which is also the current tip of its `main` — 0 commits apart) to determine what could actually move out of native GitHub Actions and into `.shipwright/workflow.yaml` beyond what PR #97 already moved (unit tests, lint, govulncheck, running in parallel).

**Conclusion: nothing more can move today.** Every remaining native check stays native because the underlying Shipwright provider genuinely doesn't exist or can't express it — not by choice.

### Gap analysis

| Check | Status | Why |
|---|---|---|
| `go build ./...` | **Stays native** | Shipwright's only `build` provider (`Ref{Name: "go"}`) compiles a single `main` binary from `.` and requires a `binaryName`. go-specs is a library with no root `main` — this provider has nothing to build. Filed [pablogore/shipwright#273](https://github.com/pablogore/shipwright/issues/273). |
| `go vet ./...` | **Stays native** | No `go-vet` provider is registered anywhere in Shipwright's manifest DSL (only its own internal dev tooling shells out to `go vet` directly). In practice `golangci-lint`'s default linter set already runs vet-equivalent checks, but that's implicit, not an explicit gate. Filed [pablogore/shipwright#274](https://github.com/pablogore/shipwright/issues/274). |
| `go test ./...` | **Already in Shipwright** | The `unit` step, unchanged since #97. |
| `go test -race ./...` | **Already in Shipwright (bonus)** | `GoUnitTester` runs `go test -v -race -coverprofile=... ./...` unconditionally — race detection was already baked into the `unit` step without anyone asking for it. Native race testing stays too, since it's the only leg that also covers macOS and the Go 1.25 floor (see below). |
| `golangci-lint` | **Already in Shipwright** | Unchanged since #97. |
| `govulncheck` | **Already in Shipwright** | Unchanged since #97. |
| Go version matrix (1.25 / stable) | **Stays native** | `go-test`'s with-fields expose only `coverage` — no Go-version knob. The provider is hardcoded to its own default toolchain version. There's also no "matrix" primitive anywhere in Shipwright's workflow manifest/engine. |
| OS matrix (Linux / macOS) | **Stays native** | Dagger only executes Linux containers (`golang:"+version"` images); there's no macOS container runtime to target. Structural, not a missing provider. |
| Deterministic DAG / concurrency | **Already in Shipwright** | `maxParallel`, all three steps sourced independently from `spec.source`, unchanged. |
| failFast / timeout | **Already in Shipwright** | Unchanged (`failFast: false`, `timeout: 10m`). |
| Composite action bootstrap | **Manual bootstrap stays** | Re-verified: `.github/actions/shipwright/action.yml`'s `cloud-token` input still has a literal `${{ secrets.DAGGER_CLOUD_TOKEN }}` in its `description:` string at both the `v0.12.0` tag and `main` tip (2026-09-10) — GitHub's parser still rejects it with `Unrecognized named-value: 'secrets'` before any job can run. Filed [pablogore/shipwright#275](https://github.com/pablogore/shipwright/issues/275). |
| Benchmark/perf gates | **Out of scope** | No benchmark-shaped capability exists in Shipwright today, and neither pipeline has one now — not adding one speculatively. |

## What this PR actually changes

Comments only, in `.github/workflows/ci.yml`:
- Documents the responsibility split explicitly (`.shipwright/workflow.yaml` = canonical CI semantics; this file = GitHub-specific bootstrap + what Shipwright can't express).
- Corrects the previous comment, which only called out the *plain* `go test` as redundant with Shipwright's `unit` step — it's actually redundant *including* `-race`, since that's baked into the provider.
- Links the three filed Shipwright gaps instead of leaving them undocumented.

No YAML structure, provider, or step changed — `.shipwright/workflow.yaml` is untouched, because there is nothing safe to add to it yet without inventing providers that don't exist.

## Validation

- `go build ./...`, `go vet ./...`, `go test ./...` all pass locally.
- `.github/workflows/ci.yml` parses as valid YAML.

## Follow-up

Once any of pablogore/shipwright#273, #274, #275 land, this repo can revisit moving `build`/`vet` into `.shipwright/workflow.yaml` and/or adopting the canonical composite action instead of the manual bootstrap.

Not merging this — opening for review per the CI architecture discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)